### PR TITLE
Fix distribution creation in PyTorchDistributionFactor

### DIFF
--- a/neuralpp/experiments/normal_factor_log_prob.py
+++ b/neuralpp/experiments/normal_factor_log_prob.py
@@ -12,21 +12,17 @@ scale = TensorVariable("scale", 0)
 
 normal_factor = NormalFactor([value, loc, scale])
 
-
-# Note: in order for this to run we will have to fix pytorch_distribution_factor.py:
-# distribution = self.pytorch_distribution_maker(*distribution_parameters)
-prob = normal_factor.call_after_validation(
+prob = normal_factor(
     {
         value: torch.tensor(0.0),
         loc: torch.tensor(0.0),
         scale: torch.tensor(1.0),
-    },
-    assignment_values=None,  # question: what does this parameter do?
+    }
 )
 
 # note to myself: this returns the probability, not log prob
 print(prob)
 
-# compare to the log prob from torch
+# compare to the log prob from calling torch distribution directly
 log_prob = dist.Normal(torch.tensor(0.0), torch.tensor(1.0)).log_prob(torch.tensor(0.0))
 assert prob == log_prob.exp()

--- a/neuralpp/experiments/normal_factor_log_prob.py
+++ b/neuralpp/experiments/normal_factor_log_prob.py
@@ -1,0 +1,32 @@
+import torch
+import torch.distributions as dist
+
+from neuralpp.inference.graphical_model.representation.factor.continuous.normal_factor import (
+    NormalFactor,
+)
+from neuralpp.inference.graphical_model.variable.tensor_variable import TensorVariable
+
+value = TensorVariable("value", 0)
+loc = TensorVariable("loc", 0)
+scale = TensorVariable("scale", 0)
+
+normal_factor = NormalFactor([value, loc, scale])
+
+
+# Note: in order for this to run we will have to fix pytorch_distribution_factor.py:
+# distribution = self.pytorch_distribution_maker(*distribution_parameters)
+prob = normal_factor.call_after_validation(
+    {
+        value: torch.tensor(0.0),
+        loc: torch.tensor(0.0),
+        scale: torch.tensor(1.0),
+    },
+    assignment_values=None,  # question: what does this parameter do?
+)
+
+# note to myself: this returns the probability, not log prob
+print(prob)
+
+# compare to the log prob from torch
+log_prob = dist.Normal(torch.tensor(0.0), torch.tensor(1.0)).log_prob(torch.tensor(0.0))
+assert prob == log_prob.exp()

--- a/neuralpp/inference/graphical_model/representation/factor/continuous/pytorch_distribution_factor.py
+++ b/neuralpp/inference/graphical_model/representation/factor/continuous/pytorch_distribution_factor.py
@@ -1,5 +1,6 @@
-from neuralpp.inference.graphical_model.representation.factor.continuous.continuous_internal_parameterless_factor import \
-    ContinuousInternalParameterlessFactor
+from neuralpp.inference.graphical_model.representation.factor.continuous.continuous_internal_parameterless_factor import (
+    ContinuousInternalParameterlessFactor,
+)
 
 
 class PyTorchDistributionFactor(ContinuousInternalParameterlessFactor):
@@ -24,8 +25,10 @@ class PyTorchDistributionFactor(ContinuousInternalParameterlessFactor):
 
     def call_after_validation(self, assignment_dict, assignment_values):
         assignment_and_conditioning_dict = self.total_conditioning_dict(assignment_dict)
-        distribution_parameters = [assignment_and_conditioning_dict[variable]
-                                   for variable in self.distribution_parameter_variables]
-        distribution = self.pytorch_distribution_maker(distribution_parameters)
+        distribution_parameters = [
+            assignment_and_conditioning_dict[variable]
+            for variable in self.distribution_parameter_variables
+        ]
+        distribution = self.pytorch_distribution_maker(*distribution_parameters)
         value = assignment_and_conditioning_dict[self.value_variable]
         return distribution.log_prob(value).exp()


### PR DESCRIPTION
This PR fixes `PyTorchDistributionFactor` by expanding `distribution_parameters` when creating a new distribution, i.e.
```
distribution = self.pytorch_distribution_maker(*distribution_parameters)
```
Before the fix, we would pass the entire list of parameters to the first positional parameter, which isn't intended.

I also included the dummy script that I wrote to experiment and learn neuralpp. Feel free to adapt it into a test or move it elsewhere. :)