### PR TITLE
implemented expression factory

### DIFF
--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
-from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression
+from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression, \
+    ExpressionFactory
 from abc import ABC
-from typing import Any, List
+from typing import Any, List, Type
 
 
 class BasicExpression(Expression, ABC):
-    def new_constant(self, value: Any) -> BasicConstant:
+    @property
+    def factory(self) -> Type[ExpressionFactory]:
+        return BasicExpressionFactory
+
+
+class BasicExpressionFactory(ExpressionFactory):
+    @staticmethod
+    def new_constant(value: Any) -> BasicConstant:
         return BasicConstant(value)
 
-    def new_variable(self, name: str) -> BasicVariable:
+    @staticmethod
+    def new_variable(name: str) -> BasicVariable:
         return BasicVariable(name)
 
-    def new_function_application(self, func: Expression, args: List[Expression]) -> BasicFunctionApplication:
+    @staticmethod
+    def new_function_application(func: Expression, args: List[Expression]) -> BasicFunctionApplication:
         return BasicFunctionApplication(func, args)
 
 

--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -14,8 +14,8 @@ class BasicExpression(Expression, ABC):
         return BasicVariable(name)
 
     @classmethod
-    def new_function_application(cls, func: Expression, args: List[Expression]) -> BasicFunctionApplication:
-        return BasicFunctionApplication(func, args)
+    def new_function_application(cls, function: Expression, arguments: List[Expression]) -> BasicFunctionApplication:
+        return BasicFunctionApplication(function, arguments)
 
 
 class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):

--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -1,27 +1,20 @@
 from __future__ import annotations
-from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression, \
-    ExpressionFactory
+from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression
 from abc import ABC
 from typing import Any, List, Type
 
 
 class BasicExpression(Expression, ABC):
-    @property
-    def factory(self) -> Type[ExpressionFactory]:
-        return BasicExpressionFactory
-
-
-class BasicExpressionFactory(ExpressionFactory):
-    @staticmethod
-    def new_constant(value: Any) -> BasicConstant:
+    @classmethod
+    def new_constant(cls, value: Any) -> BasicConstant:
         return BasicConstant(value)
 
-    @staticmethod
-    def new_variable(name: str) -> BasicVariable:
+    @classmethod
+    def new_variable(cls, name: str) -> BasicVariable:
         return BasicVariable(name)
 
-    @staticmethod
-    def new_function_application(func: Expression, args: List[Expression]) -> BasicFunctionApplication:
+    @classmethod
+    def new_function_application(cls, func: Expression, args: List[Expression]) -> BasicFunctionApplication:
         return BasicFunctionApplication(func, args)
 
 

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -65,7 +65,7 @@ class Expression(ABC):
 
     @classmethod
     @abstractmethod
-    def new_function_application(cls, func: Expression, args: List[Expression]) -> FunctionApplication:
+    def new_function_application(cls, function: Expression, arguments: List[Expression]) -> FunctionApplication:
         pass
 
 

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -53,26 +53,19 @@ class Expression(ABC):
     def __eq__(self, other) -> bool:
         pass
 
-    @property
+    @classmethod
     @abstractmethod
-    def factory(self) -> Type[ExpressionFactory]:
+    def new_constant(cls, value: Any) -> Constant:
         pass
 
-
-class ExpressionFactory(ABC):
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def new_constant(value: Any) -> Constant:
+    def new_variable(cls, name: str) -> Variable:
         pass
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def new_variable(name: str) -> Variable:
-        pass
-
-    @staticmethod
-    @abstractmethod
-    def new_function_application(func: Expression, args: List[Expression]) -> FunctionApplication:
+    def new_function_application(cls, func: Expression, args: List[Expression]) -> FunctionApplication:
         pass
 
 
@@ -158,13 +151,13 @@ class FunctionApplication(Expression, ABC):
 
     def set(self, i: int, new_expression: Expression) -> Expression:
         if i == 0:
-            return self.factory.new_function_application(new_expression, self.arguments)
+            return self.new_function_application(new_expression, self.arguments)
 
         arity = len(self.arguments)  # evaluate len after i != 0, if i == 0 we can be lazy
         if i-1 < arity:
             arguments = self.arguments
             arguments[i-1] = new_expression
-            return self.factory.new_function_application(self.function, arguments)
+            return self.new_function_application(self.function, arguments)
         else:
             raise IndexError(f"Out of scope. Function only has arity {arity} but you are setting {i-1}th arguments.")
 
@@ -174,4 +167,4 @@ class FunctionApplication(Expression, ABC):
             to_expression if e == from_expression else e.replace(from_expression, to_expression)
             for e in self.subexpressions
         ]
-        return self.factory.new_function_application(new_subexpressions[0], new_subexpressions[1:])
+        return self.new_function_application(new_subexpressions[0], new_subexpressions[1:])


### PR DESCRIPTION
The idea is to have an ExpressionFactory where all new_* method can be static to that class. And adding an abstract property factory to Expression. 

For example, previously, if we were to call `new_constant()` of `BasicExpression`, we need to create a dummy object of `BasicExpression` first, for example, `BasicConstant("dummy")`, then call `BasicConstant("dummy").new_constant(..)`. This feels a bit ugly to me especially when writing tests. With ExpressionFactory we can just do `BasicExpressionFactory.new_constant(..)`.