### PR TITLE
Typing for expressions.

### DIFF
--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -1,25 +1,68 @@
 from __future__ import annotations
-from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression
+
+import operator
+import builtins
+from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression, \
+    VariableNotTypedError, FunctionType
 from abc import ABC
-from typing import Any, List, Type
+from typing import Any, List, Optional, Type, Callable, Tuple
+
+
+class AmbiguousTypeError(TypeError, ValueError):
+    def __init__(self, python_callable: Callable):
+        super().__init__(f"{python_callable} is ambiguous.")
+
+
+def infer_python_callable_type(python_callable: Callable) -> FunctionType:
+    match python_callable:
+        # boolean operation
+        case operator.__and__ | operator.__or__ | operator.__xor__:
+            raise AmbiguousTypeError(python_callable)  # this is also ambiguous because the arity could be arbitrary
+            # return FunctionType([bool, bool], bool)
+        case operator.__not__:
+            return FunctionType([bool], bool)
+        # comparison
+        case operator.le | operator.lt | operator.ge | operator.gt | operator.eq:
+            raise AmbiguousTypeError(python_callable)
+        # arithmetic
+        case operator.add | operator.mul | operator.pow:
+            raise AmbiguousTypeError(python_callable)
+        # min/max
+        case builtins.min | builtins.max:
+            raise AmbiguousTypeError(python_callable)
+        case _:
+            raise ValueError(f"Python callable {python_callable} is not recognized.")
 
 
 class BasicExpression(Expression, ABC):
     @classmethod
-    def new_constant(cls, value: Any) -> BasicConstant:
-        return BasicConstant(value)
+    def new_constant(cls, value: Any, constant_type: Optional[Expression] = None) -> BasicConstant:
+        return BasicConstant(value, constant_type)
 
     @classmethod
-    def new_variable(cls, name: str) -> BasicVariable:
-        return BasicVariable(name)
+    def new_variable(cls, name: str, variable_type: Expression) -> BasicVariable:
+        return BasicVariable(name, variable_type)
 
     @classmethod
     def new_function_application(cls, function: Expression, arguments: List[Expression]) -> BasicFunctionApplication:
         return BasicFunctionApplication(function, arguments)
 
 
+def new_type(python_type: Type) -> Expression:
+    """ A handy method to create properly wrapped type as an Expression. E.g., new_type(int). """
+    return BasicConstant(python_type)
+
+
 class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):
-    def __init__(self, atom: Any):
+    def __init__(self, atom: Any, expression_type: Optional[Expression] = None):
+        if expression_type is None and not Expression.is_internal_type(atom):
+            # try to infer type for atom
+            if isinstance(atom, Callable):
+                internal_type = infer_python_callable_type(atom)
+            else:
+                internal_type = type(atom)
+            expression_type = BasicConstant(internal_type, None)
+        super().__init__(expression_type)
         self._atom = atom
 
     @property
@@ -28,17 +71,25 @@ class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):
 
 
 class BasicVariable(BasicAtomicExpression, Variable):
-    def __init__(self, name: str):
-        BasicAtomicExpression.__init__(self, name)
+    def __init__(self, name: str, variable_type: Expression):
+        if variable_type is None:
+            raise VariableNotTypedError
+        BasicAtomicExpression.__init__(self, name, variable_type)
 
 
 class BasicConstant(BasicAtomicExpression, Constant):
-    def __init__(self, value: Any):
-        BasicAtomicExpression.__init__(self, value)
+    def __init__(self, value: Any, constant_type: Optional[Expression] = None):
+        BasicAtomicExpression.__init__(self, value, constant_type)
+
+    # just add this one to simplify debugging
+    def __str__(self) -> str:
+        return f"{self.value}: {self.type}"
 
 
 class BasicFunctionApplication(BasicExpression, FunctionApplication):
     def __init__(self, function: Expression, arguments: List[Expression]):
+        function_type = BasicConstant(function.get_return_type(len(arguments)))
+        super().__init__(function_type)
         self._subexpressions = [function] + arguments
 
     @property
@@ -52,3 +103,7 @@ class BasicFunctionApplication(BasicExpression, FunctionApplication):
     @property
     def subexpressions(self) -> List[Expression]:
         return self._subexpressions
+
+    @property
+    def number_of_arguments(self) -> int:
+        return len(self.arguments)

--- a/neuralpp/symbolic/basic_interpreter.py
+++ b/neuralpp/symbolic/basic_interpreter.py
@@ -20,7 +20,7 @@ class BasicInterpreter(Interpreter):
             # there's three cases of `function` that BasicInterpreter can eval():
             # 1. a Python callable, which we'll directly call
             # 2. an uninterpreted function, which is not callable. We raise Error when encounter it.
-            case FunctionApplication(function=Constant(value=python_callable), arguments=args):
+            case FunctionApplication(function=Constant(value=python_callable), arguments=args, type=_):
                 # * is used to turn a list into "args": https://docs.python.org/2/reference/expressions.html#calls
                 return python_callable(*[self.eval(e, BasicConstant(True)) for e in args])
             case FunctionApplication(function=Variable(name=f), arguments=_):

--- a/neuralpp/symbolic/basic_interpreter.py
+++ b/neuralpp/symbolic/basic_interpreter.py
@@ -4,7 +4,7 @@ from neuralpp.symbolic.basic_expression import BasicConstant
 
 
 class BasicInterpreter(Interpreter):
-    def eval(self, expression: Expression, context: Expression):
+    def eval(self, expression: Expression, context: Expression = BasicConstant(True)):
         """
         In this BasicInterpreter, `context` is ignored and assumed to be True.
         `expression` is assumed to only (recursively) contain FunctionaApplication and Constant.
@@ -20,9 +20,9 @@ class BasicInterpreter(Interpreter):
             # there's three cases of `function` that BasicInterpreter can eval():
             # 1. a Python callable, which we'll directly call
             # 2. an uninterpreted function, which is not callable. We raise Error when encounter it.
-            case FunctionApplication(function=Constant(value=python_callable), arguments=args, type=_):
+            case FunctionApplication(function=Constant(value=python_callable), arguments=args):
                 # * is used to turn a list into "args": https://docs.python.org/2/reference/expressions.html#calls
-                return python_callable(*[self.eval(e, BasicConstant(True)) for e in args])
+                return python_callable(*map(self.eval, args))
             case FunctionApplication(function=Variable(name=f), arguments=_):
                 raise AttributeError(f"Function {f} is uninterpreted. It cannot be evaluated by BasicInterpreter.")
             case Constant(value=value):

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -36,17 +36,6 @@ class FunctionType:
 
 class Expression(ABC):
     def __init__(self, expression_type: Expression):
-        """
-        All types are represented by a function-style 2-element tuple (argument_types, return_type),
-        where argument_types is a list of argument types.
-        For simple type such as int, it's treated as an arity=0 function, i.e., ([], int).
-        We refer to this tuple type representation as "internal type".
-
-        The reason I do not use "typing.Callable | int | float ..." is that it's not a unified system,
-        for example, we have
-            not isinstance(typing.Callable, type) and isinstance(int, type)
-            not isinstance(typing.Callable, typing.Type) and isinstance(int, typing.Type)
-        """
         self._type = expression_type
 
     @staticmethod

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -1,9 +1,58 @@
 from __future__ import annotations  # to support forward reference for recursive type reference
-from typing import Any, List
+
+from typing import List, Any, Optional, Tuple, Type, NewType
 from abc import ABC, abstractmethod
 
 
+class FunctionType:
+    def __init__(self, argument_types: List[Type], return_type: Type):
+        self._argument_types = argument_types
+        self._return_type = return_type
+
+    @property
+    def argument_types(self):
+        return self._argument_types
+
+    @property
+    def return_type(self):
+        return self._return_type
+
+    @property
+    def arity(self):
+        return len(self._argument_types)
+
+    def return_type_after_application(self, number_of_arguments: int) -> FunctionType | Type:
+        """ Given number_of_arguments (<=arity), return the return type after (partial) application. """
+        if number_of_arguments > self.arity:
+            raise ValueError(f"number_of_arguments {number_of_arguments} > arity {self.arity}.")
+        elif number_of_arguments == self.arity:
+            return self.return_type
+        else:
+            return FunctionType(self.argument_types[number_of_arguments:], self.return_type)
+
+    def __str__(self) -> str:
+        return f"{self.argument_types} -> {self.return_type}"
+
+
 class Expression(ABC):
+    def __init__(self, expression_type: Expression):
+        """
+        All types are represented by a function-style 2-element tuple (argument_types, return_type),
+        where argument_types is a list of argument types.
+        For simple type such as int, it's treated as an arity=0 function, i.e., ([], int).
+        We refer to this tuple type representation as "internal type".
+
+        The reason I do not use "typing.Callable | int | float ..." is that it's not a unified system,
+        for example, we have
+            not isinstance(typing.Callable, type) and isinstance(int, type)
+            not isinstance(typing.Callable, typing.Type) and isinstance(int, typing.Type)
+        """
+        self._type = expression_type
+
+    @staticmethod
+    def is_internal_type(atom: Any):
+        return isinstance(atom, FunctionType | Type)
+
     @property
     @abstractmethod
     def subexpressions(self) -> List[Expression]:
@@ -55,12 +104,12 @@ class Expression(ABC):
 
     @classmethod
     @abstractmethod
-    def new_constant(cls, value: Any) -> Constant:
+    def new_constant(cls, value: Any, constant_type: Optional[Expression]) -> Constant:
         pass
 
     @classmethod
     @abstractmethod
-    def new_variable(cls, name: str) -> Variable:
+    def new_variable(cls, name: str, variable_type: Expression) -> Variable:
         pass
 
     @classmethod
@@ -74,14 +123,40 @@ class Expression(ABC):
         if isinstance(from_expression, cls):
             return from_expression
         match from_expression:
-            case Constant(value=value):
-                return cls.new_constant(value)
-            case Variable(name=name):
-                return cls.new_variable(name)
-            case FunctionApplication(function=function, arguments=arguments):
+            case Constant(value=value, type=constant_type):
+                return cls.new_constant(value, constant_type)
+            case Variable(name=name, type=variable_type):
+                return cls.new_variable(name, variable_type)
+            case FunctionApplication(function=function, arguments=arguments, type=function_type):
                 return cls.new_function_application(function, arguments)
             case _:
                 raise ValueError(f"invalid from_expression {from_expression}: {type(from_expression)}")
+
+    @property
+    def type(self) -> Expression:
+        return self._type
+
+    def get_function_type(self) -> FunctionType | Type:
+        """ Call me when self is a function """
+        match self:
+            case Constant(type=type_expression) | Variable(type=type_expression):
+                return type_expression.get_function_type_of_type_expression()
+            case FunctionApplication(function=function, number_of_arguments=num):
+                return function.get_return_type(num)
+
+    def get_function_type_of_type_expression(self) -> FunctionType | Type:
+        """ Call me when self is a type Expression of a function """
+        match self:
+            case Constant(value=internal_type):
+                if not Expression.is_internal_type(internal_type):
+                    raise TypeError(f"{internal_type} is not internal type.")
+                return internal_type
+            case _:
+                raise TypeError(f"Unrecognized type expression {self}.")
+
+    def get_return_type(self, number_of_arguments: int) -> FunctionType | Type:
+        function_type = self.get_function_type()
+        return function_type.return_type_after_application(number_of_arguments)
 
 
 class AtomicExpression(Expression, ABC):
@@ -110,8 +185,8 @@ class AtomicExpression(Expression, ABC):
 
     def __eq__(self, other) -> bool:
         match other:
-            case AtomicExpression(base_type=other_base_type, atom=other_atom):
-                return other_base_type == self.base_type and self.atom == other_atom
+            case AtomicExpression(base_type=other_base_type, atom=other_atom, type=other_type):
+                return other_base_type == self.base_type and self.atom == other_atom and self.type == other_type
             case _:
                 return False
 
@@ -140,11 +215,19 @@ class Constant(AtomicExpression, ABC):
 
 
 class FunctionApplication(Expression, ABC):
-    __match_args__ = ("function", "arguments")
+    __match_args__ = ("function", "arguments", "number_of_arguments")
 
     @property
     @abstractmethod
     def function(self) -> Expression:
+        pass
+
+    @property
+    @abstractmethod
+    def number_of_arguments(self) -> int:
+        # in some implementation getting number_of_arguments without calling arguments is useful,
+        # e.g., a lazy implementation where arguments are only evaluated when used
+        # Note: this is not `arity`, which is a property of a function, not a function application.
         pass
 
     @property
@@ -159,8 +242,8 @@ class FunctionApplication(Expression, ABC):
 
     def __eq__(self, other):
         match other:
-            case FunctionApplication(function=function, arguments=arguments):
-                return self.subexpressions == [function] + arguments
+            case FunctionApplication(function=function, arguments=arguments, type=other_type):
+                return self.subexpressions == [function] + arguments and self.type == other_type
             case _:
                 return False
 
@@ -168,13 +251,14 @@ class FunctionApplication(Expression, ABC):
         if i == 0:
             return self.new_function_application(new_expression, self.arguments)
 
-        arity = len(self.arguments)  # evaluate len after i != 0, if i == 0 we can be lazy
-        if i-1 < arity:
+        # evaluate len after i != 0, if i == 0 we can be lazy
+        if i-1 < self.number_of_arguments:
             arguments = self.arguments
             arguments[i-1] = new_expression
             return self.new_function_application(self.function, arguments)
         else:
-            raise IndexError(f"Out of scope. Function only has arity {arity} but you are setting {i-1}th arguments.")
+            raise IndexError(f"Out of scope. Function application only has {self.number_of_arguments} arguments "
+                             f"but you are setting {i-1}th arguments.")
 
     def replace(self, from_expression: Expression, to_expression: Expression) -> Expression:
         # recursively do the replacement
@@ -183,3 +267,15 @@ class FunctionApplication(Expression, ABC):
             for e in self.subexpressions
         ]
         return self.new_function_application(new_subexpressions[0], new_subexpressions[1:])
+
+
+class NotTypedError(ValueError, TypeError):
+    pass
+
+
+class VariableNotTypedError(NotTypedError):
+    pass
+
+
+class FunctionNotTypedError(NotTypedError):
+    pass

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -5,6 +5,7 @@ from abc import ABC
 import sympy
 import operator
 import builtins
+import fractions
 from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, \
     FunctionNotTypedError, NotTypedError, FunctionType
 from neuralpp.symbolic.basic_expression import BasicConstant, new_type, infer_python_callable_type
@@ -21,6 +22,8 @@ def infer_sympy_object_type(sympy_object: sympy.Basic, type_dict: Dict[sympy.Bas
             return BasicConstant(int)
         case sympy.Float():
             return BasicConstant(float)
+        case sympy.Rational():
+            return BasicConstant(fractions.Fraction)
         case sympy.logic.boolalg.BooleanAtom():
             return BasicConstant(bool)
         case _:
@@ -122,6 +125,8 @@ class SymPyExpression(Expression, ABC):
             sympy_object = sympy.Integer(value)
         elif type(value) == float:
             sympy_object = sympy.Float(value)
+        elif type(value) == fractions.Fraction:
+            sympy_object = sympy.Rational(value)
         elif type(value) == str:
             sympy_object = sympy.Function(value)
             if constant_type is None:

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -1,52 +1,74 @@
 from __future__ import annotations
-from typing import List, Any, Type, Callable, Tuple
+from typing import List, Any, Type, Callable, Tuple, Optional, Dict
 from abc import ABC
 
 import sympy
 import operator
 import builtins
-from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant
+from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, \
+    FunctionNotTypedError, NotTypedError, FunctionType
+from neuralpp.symbolic.basic_expression import BasicConstant, new_type, infer_python_callable_type
+from neuralpp.util.util import consistently_update_dict
+
 
 # In this file's doc, I try to avoid the term `sympy expression` because it could mean both sympy.Expr (or sympy.Basic)
 # and SymPyExpression. I usually use "sympy object" to refer to the former and "expression" to refer to the latter.
 
 
-def python_callable_to_sympy_function(python_callable: Callable) -> Type[sympy.Basic]:
-    match python_callable:
-        # boolean operation
-        case operator.__and__:
-            return sympy.And
-        case operator.__or__:
-            return sympy.Or
-        case operator.__not__:
-            return sympy.Not
-        case operator.__xor__:
-            return sympy.Xor
-        # comparison
-        case operator.le:
-            return sympy.Le
-        case operator.lt:
-            return sympy.Lt
-        case operator.ge:
-            return sympy.Ge
-        case operator.gt:
-            return sympy.Gt
-        case operator.eq:
-            return sympy.Eq
-        # arithmetic
-        case operator.add:
-            return sympy.Add
-        case operator.mul:
-            return sympy.Mul
-        case operator.pow:
-            return sympy.Pow
-        # min/max
-        case builtins.min:
-            return sympy.Min
-        case builtins.max:
-            return sympy.Max
+def infer_sympy_object_type(sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, Expression]) -> Expression:
+    match sympy_object:
+        case sympy.Integer():
+            return BasicConstant(int)
+        case sympy.Float():
+            return BasicConstant(float)
+        case sympy.logic.boolalg.BooleanAtom():
+            return BasicConstant(bool)
         case _:
-            raise ValueError(f"Python callable {python_callable} is not recognized.")
+            # It is obvious that we can look up type_dict for symbols like `symbol("x")`.
+            # We can also look up for function, such as `a+b`, where type_dict records the function type (instead of
+            # return type) of the (root-level) function.
+            try:
+                return type_dict[sympy_object]
+            except KeyError:  # if it's not in type_dict, try figure out ourselves
+                return BasicConstant(infer_python_callable_type(sympy_function_to_python_callable(sympy_object)))
+
+
+python_callable_and_sympy_function_pair = [
+    # boolean operation
+    (operator.__and__, sympy.And),
+    (operator.__or__, sympy.Or),
+    (operator.__not__, sympy.Not),
+    (operator.__xor__, sympy.Xor),
+    # comparison
+    (operator.le, sympy.Le),
+    (operator.lt, sympy.Lt),
+    (operator.ge, sympy.Ge),
+    (operator.gt, sympy.Gt),
+    (operator.eq, sympy.Eq),
+    # arithmetic
+    (operator.add, sympy.Add),
+    (operator.mul, sympy.Mul),
+    (operator.pow, sympy.Pow),
+    # min/max
+    (builtins.min, sympy.Min),
+    (builtins.max, sympy.Max),
+]
+
+
+def sympy_function_to_python_callable(sympy_function: sympy.Basic) -> Callable:
+    try:
+        return {sympy_function: python_callable
+                for python_callable, sympy_function in python_callable_and_sympy_function_pair}[sympy_function]
+    except KeyError:
+        raise ValueError(f"SymPy function {sympy_function} is not recognized.")
+
+
+def python_callable_to_sympy_function(python_callable: Callable) -> sympy.Basic:
+    try:
+        return {python_callable: sympy_function
+                for python_callable, sympy_function in python_callable_and_sympy_function_pair}[python_callable]
+    except KeyError:
+        raise ValueError(f"Python callable {python_callable} is not recognized.")
 
 
 def is_sympy_value(sympy_object: sympy.Basic) -> bool:
@@ -54,22 +76,43 @@ def is_sympy_value(sympy_object: sympy.Basic) -> bool:
            isinstance(sympy_object, sympy.logic.boolalg.BooleanAtom)
 
 
-def sympy_object_to_expression(sympy_object: sympy.Basic) -> SymPyExpression:
+def sympy_object_to_expression(sympy_object: sympy.Basic, argument_type: Expression,
+                               type_dict: Dict[sympy.Basic, Expression]) -> SymPyExpression:
     # Here we just try to find a type of expression for sympy object.
     if type(sympy_object) == sympy.Symbol:
-        return SymPyVariable(sympy_object)
+        return SymPyVariable(sympy_object, argument_type)
     elif is_sympy_value(sympy_object):
-        return SymPyConstant(sympy_object)
+        return SymPyConstant(sympy_object, argument_type)
     else:
-        return SymPyFunctionApplication(sympy_object)
+        return SymPyFunctionApplication(sympy_object, type_dict, type_dict[sympy_object])
+
+
+def build_type_dict(sympy_arguments: SymPyExpression, type_dict: Dict[sympy.Basic, Expression]) -> None:
+    consistently_update_dict(type_dict, sympy_arguments.type_dict)
+
+
+def build_type_dict_from_sympy_arguments(sympy_arguments: List[SymPyExpression]) -> Dict[sympy.Basic, Expression]:
+    """
+    Assumption: each element in sympy_arguments has a proper type_dict.
+    Returns: a proper type_dict with these arguments joint
+    """
+    result = {}
+    for sympy_argument in sympy_arguments:
+        build_type_dict(sympy_argument, result)
+    return result
 
 
 class SymPyExpression(Expression, ABC):
-    def __init__(self, sympy_object: sympy.Basic):
+    def __init__(self, sympy_object: sympy.Basic, expression_type: Expression,
+                 type_dict: Dict[sympy.Basic, Expression]):
+        if expression_type is None:
+            raise NotTypedError
+        super().__init__(expression_type)
         self._sympy_object = sympy_object
+        self._type_dict = type_dict
 
     @classmethod
-    def new_constant(cls, value: Any) -> SymPyConstant:
+    def new_constant(cls, value: Any, constant_type: Optional[Expression] = None) -> SymPyConstant:
         # if a string contains a whitespace it'll be treated as multiple variables in sympy.symbols
         if isinstance(value, sympy.Basic):
             sympy_object = value
@@ -81,21 +124,23 @@ class SymPyExpression(Expression, ABC):
             sympy_object = sympy.Float(value)
         elif type(value) == str:
             sympy_object = sympy.Function(value)
+            if constant_type is None:
+                raise FunctionNotTypedError
         else:
             try:
                 sympy_object = python_callable_to_sympy_function(value)
             except Exception:
                 raise ValueError(f"SymPyConstant does not support {type(value)}: "
                                  f"unable to turn into a sympy representation internally")
-        return SymPyConstant(sympy_object)
+        return SymPyConstant(sympy_object, constant_type)
 
     @classmethod
-    def new_variable(cls, name: str) -> SymPyVariable:
+    def new_variable(cls, name: str, variable_type: Expression) -> SymPyVariable:
         # if a string contains a whitespace it'll be treated as multiple variables in sympy.symbols
         if ' ' in name:
             raise ValueError(f"`{name}` should not contain a whitespace!")
         sympy_var = sympy.symbols(name)
-        return SymPyVariable(sympy_var)
+        return SymPyVariable(sympy_var, variable_type)
 
     @classmethod
     def new_function_application(cls, function: Expression, arguments: List[Expression]) -> SymPyFunctionApplication:
@@ -104,19 +149,15 @@ class SymPyExpression(Expression, ABC):
         match function:
             # first check if function is of SymPyConstant, where sympy_function is assumed to be a sympy function,
             # and we don't need to convert it.
-            case SymPyConstant(value=sympy_function):
-                return SymPyFunctionApplication(sympy_function(*[cls._convert(argument).sympy_object
-                                                                 for argument in arguments],
-                                                               evaluate=False))  # otherwise Add(1,1) will be 2 in sympy
+            case SymPyConstant(value=sympy_function, type=function_type):
+                return SymPyFunctionApplication.from_sympy_function_and_general_arguments(
+                    sympy_function, function_type, arguments)
             # if function is not of SymPyConstant but of Constant, then it is assumed to be a python callable
-            case Constant(value=python_callable):
+            case Constant(value=python_callable, type=function_type):
                 # during the call, ValueError will be implicitly raised if we cannot convert
                 sympy_function = python_callable_to_sympy_function(python_callable)
-                # mutual recursively call _convert().
-                # this wll guarantee type of cls._convert(argument) is SymPyExpression
-                return SymPyFunctionApplication(sympy_function(*[cls._convert(argument).sympy_object
-                                                                 for argument in arguments],
-                                                               evaluate=False))
+                return SymPyFunctionApplication.from_sympy_function_and_general_arguments(
+                    sympy_function, function_type, arguments)
             case Variable(name=name):
                 raise ValueError(f"Cannot create a SymPyExpression from uninterpreted function {name}")
             case FunctionApplication(_, _):
@@ -128,27 +169,65 @@ class SymPyExpression(Expression, ABC):
     def sympy_object(self):
         return self._sympy_object
 
+    @property
+    def type_dict(self) -> Dict[sympy.Basic, Expression]:
+        return self._type_dict
+
 
 class SymPyVariable(SymPyExpression, Variable):
+    def __init__(self, sympy_object: sympy.Basic, expression_type: Expression):
+        SymPyExpression.__init__(self, sympy_object, expression_type, {sympy_object: expression_type})
+
     @property
     def atom(self) -> str:
         return str(self._sympy_object)
 
 
 class SymPyConstant(SymPyExpression, Constant):
+    def __init__(self, sympy_object: sympy.Basic, expression_type: Optional[Expression] = None):
+        if expression_type is None:
+            expression_type = infer_sympy_object_type(sympy_object, {})
+        SymPyExpression.__init__(self, sympy_object, expression_type, {sympy_object: expression_type})
+
     @property
     def atom(self) -> Any:
         return self._sympy_object
 
 
 class SymPyFunctionApplication(SymPyExpression, FunctionApplication):
+    def __init__(self, sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, Expression],
+                 function_type: Optional[Expression] = None):
+        if function_type is None:
+            # it's useless to supply type_dict since we are looking for self.type, which is not set in type_dict yet.
+            function_type = infer_sympy_object_type(sympy_object.func, {})  # almost useless, can only infer "not"
+
+        if len(sympy_object.args) == 0:
+            raise TypeError("not a function application.")
+
+        if sympy_object not in type_dict:
+            type_dict[sympy_object] = function_type
+        else:
+            if type_dict[sympy_object] != function_type:
+                raise ValueError(f"Inconsistent type for {sympy_object}: {function_type} and "
+                                 f"{type_dict[sympy_object]}.")
+
+        self._function_type = function_type
+        return_type = function_type.get_function_type_of_type_expression().\
+            return_type_after_application(len(sympy_object.args))
+        SymPyExpression.__init__(self, sympy_object, BasicConstant(return_type), type_dict)
+
+    @property
+    def number_of_arguments(self) -> int:
+        return len(self.native_arguments)
+
     @property
     def function(self) -> Expression:
-        return SymPyConstant(self._sympy_object.func)
+        return SymPyConstant(self._sympy_object.func, self._function_type)
 
     @property
     def arguments(self) -> List[Expression]:
-        return [sympy_object_to_expression(argument) for argument in self._sympy_object.args]
+        return [sympy_object_to_expression(argument, infer_sympy_object_type(argument, self.type_dict), self.type_dict)
+                for argument in self.native_arguments]
 
     @property
     def native_arguments(self) -> Tuple[sympy.Basic, ...]:
@@ -158,3 +237,12 @@ class SymPyFunctionApplication(SymPyExpression, FunctionApplication):
     @property
     def subexpressions(self) -> List[Expression]:
         return [self.function] + self.arguments
+
+    @staticmethod
+    def from_sympy_function_and_general_arguments(sympy_function: sympy.Basic, function_type: Expression,
+                                                  arguments: List[Expression]) -> SymPyFunctionApplication:
+        sympy_arguments = [SymPyExpression._convert(argument) for argument in arguments]
+        type_dict = build_type_dict_from_sympy_arguments(sympy_arguments)
+        sympy_object = sympy_function(*[sympy_argument.sympy_object for sympy_argument in sympy_arguments],
+                                      evaluate=False)  # Stop evaluation, otherwise Add(1,1) will be 2 in sympy
+        return SymPyFunctionApplication(sympy_object, type_dict, function_type)

--- a/neuralpp/symbolic/sympy_interpreter.py
+++ b/neuralpp/symbolic/sympy_interpreter.py
@@ -1,6 +1,7 @@
 import sympy
 
 from neuralpp.symbolic.expression import Expression, FunctionApplication, Constant, Variable
+from neuralpp.symbolic.basic_expression import BasicConstant
 from neuralpp.symbolic.simplifier import Simplifier
 from neuralpp.symbolic.interpreter import Interpreter
 from neuralpp.symbolic.sympy_expression import SymPyExpression, is_sympy_value
@@ -34,7 +35,7 @@ def context_to_variable_value_dict(context: Expression) -> \
 
 
 class SymPyInterpreter(Interpreter, Simplifier):
-    def eval(self, expression: SymPyExpression, context: Expression):
+    def eval(self, expression: SymPyExpression, context: Expression = BasicConstant(True)):
         variable_value_dict = context_to_variable_value_dict(context)
         # in creation of function application, we set evaluate=False, so 1 + 2 will not evaluate
         # call simplify() evaluates that

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -1,11 +1,13 @@
 import pytest
 import operator
 import sympy
+import builtins
 
+from neuralpp.symbolic.expression import FunctionType
 from neuralpp.symbolic.basic_expression import BasicFunctionApplication, BasicConstant, BasicVariable, \
-    BasicExpression
-from neuralpp.symbolic.sympy_expression import SymPyFunctionApplication, SymPyConstant, SymPyVariable, \
-    SymPyExpression
+    BasicExpression, new_type
+from neuralpp.symbolic.sympy_expression import SymPyConstant, SymPyExpression, python_callable_to_sympy_function, \
+    sympy_function_to_python_callable
 
 
 @pytest.fixture(params=[BasicExpression, SymPyExpression])
@@ -16,7 +18,7 @@ def expression_factory(request):
 def test_constant(expression_factory):
     # Constant can be anything
     constant_one = expression_factory.new_constant(1)
-    constant_abc = expression_factory.new_constant("abc")
+    constant_abc = expression_factory.new_constant("abc", BasicConstant(([int], int)))
     assert constant_one != constant_abc
     assert constant_one == expression_factory.new_constant(2-1)
     assert constant_one.subexpressions == []
@@ -40,19 +42,20 @@ def test_basic_constant():
 
 
 def test_sympy_constant():
-    constant_sympy_obj = SymPyConstant(sympy.Rational(1, 3))
-    constant_sympy_obj2 = SymPyConstant(sympy.Rational(3, 9))
+    constant_sympy_obj = SymPyConstant(sympy.Rational(1, 3), BasicConstant(float))
+    constant_sympy_obj2 = SymPyConstant(sympy.Rational(3, 9), BasicConstant(float))
     assert constant_sympy_obj == constant_sympy_obj2
-    constant_abc = SymPyExpression.new_constant("abc")
+    constant_abc = SymPyExpression.new_constant("abc", BasicConstant(FunctionType([int, int], int)))
     assert constant_abc.value == sympy.Function("abc")
 
 
 def test_variable(expression_factory):
     # Variable is initialized by a variable name.
-    variable_x = expression_factory.new_variable("x")
-    variable_y = expression_factory.new_variable("y")
+    variable_x = expression_factory.new_variable("x", BasicConstant(int))
+    variable_y = expression_factory.new_variable("y", BasicConstant(int))
     assert variable_x != variable_y
-    assert variable_x == expression_factory.new_variable("x")
+    assert variable_x == expression_factory.new_variable("x", BasicConstant(int))
+    assert variable_x != expression_factory.new_variable("x", BasicConstant(float))  # must be of the same type
     assert variable_x.subexpressions == []
     assert not variable_x.contains(variable_y)
     assert variable_x.contains(variable_x)
@@ -64,25 +67,31 @@ def test_variable(expression_factory):
 
 
 def test_basic_function_application():
+    int_to_int_to_int = BasicConstant(FunctionType([int, int], int))  # int -> int -> int
+    int_type = new_type(int)
+
     # function application has the interface FunctionApplication(func: Expression, args: List[Expression]).
     # Note that the first argument `func` is of Expression type.
     # There are 2 possible choices of `func` for a meaningful BasicFunctionApplication:
-
     # 1. a Python Callable
-    func1 = BasicConstant(lambda x, y: x + y)
+    func1 = BasicConstant(lambda x, y: x + y, int_to_int_to_int)
     constant_one = BasicConstant(1)
     constant_two = BasicConstant(2)
     fa1 = BasicFunctionApplication(func1, [constant_one, constant_two])
+    # type of function application (i.e., the return type) is optional
+    assert fa1 == BasicFunctionApplication(func1, [constant_one, constant_two])
+    assert BasicFunctionApplication(func1, [constant_one, constant_two]).type == int_type
     # using operator.add is easy to compare (operator.add == operator.add) and thus more desirable than using lambda.
-    func2 = BasicConstant(operator.add)
+    func2 = BasicConstant(operator.add, int_to_int_to_int)
     fa2 = BasicFunctionApplication(func2, [constant_one, constant_two])
 
     # 2. a Variable. In this case the function is uninterpreted. Even it's named "add", it does not necessarily
     # have to be a function of addition.
-    func3 = BasicConstant(BasicVariable("add"))
-    fa3 = BasicFunctionApplication(func3, [constant_one, fa2])  # use fa2 here, expression can be recursive
+    func3 = BasicVariable("add", int_to_int_to_int)
+    # use fa2 here, expression can be recursive
+    fa3 = BasicFunctionApplication(func3, [constant_one, fa2])
 
-    assert fa2.subexpressions == [BasicConstant(operator.add), constant_one, constant_two]
+    assert fa2.subexpressions == [BasicConstant(operator.add, int_to_int_to_int), constant_one, constant_two]
     assert fa2 == fa2
     # python cannot check __eq__ of two lambdas, so we have the following inequality
     assert fa1.subexpressions != [lambda x, y: x + y, constant_one, constant_two]
@@ -104,11 +113,11 @@ def test_basic_function_application():
                                                    BasicFunctionApplication(func2, [constant_one, constant_one])])
 
     # set() is also not changing the object that it is called on
-    fa5 = fa2.set(0, BasicVariable("f"))
-    assert fa5 == BasicFunctionApplication(BasicVariable("f"), [constant_one, constant_two])
+    fa5 = fa2.set(0, BasicVariable("f", int_to_int_to_int))
+    assert fa5 == BasicFunctionApplication(BasicVariable("f", int_to_int_to_int), [constant_one, constant_two])
     assert fa2 == BasicFunctionApplication(func2, [constant_one, constant_two])
-    fa6 = fa2.set(1, BasicVariable("a"))
-    assert fa6 == BasicFunctionApplication(func2, [BasicVariable("a"), constant_two])
+    fa6 = fa2.set(1, BasicVariable("a", int_type))
+    assert fa6 == BasicFunctionApplication(func2, [BasicVariable("a", int_type), constant_two])
     with pytest.raises(IndexError):
         fa4.set(3, constant_one)
 
@@ -117,10 +126,32 @@ def test_basic_function_application():
                                                    BasicFunctionApplication(func2, [constant_two, constant_two])])
 
 
+@pytest.fixture(params=[sympy.And, sympy.Or, sympy.Not, sympy.Xor, sympy.Le, sympy.Lt, sympy.Ge, sympy.Gt, sympy.Eq,
+                        sympy.Add, sympy.Mul, sympy.Pow, sympy.Min, sympy.Max])
+def sympy_func(request):
+    return request.param
+
+
+def test_python_callable_and_sympy_function_conversion(sympy_func):
+    assert python_callable_to_sympy_function(sympy_function_to_python_callable(sympy_func)) == sympy_func
+
+
+@pytest.fixture(params=[operator.__and__, operator.__or__, operator.__not__, operator.__xor__, operator.le,
+                        operator.lt, operator.ge, operator.gt, operator.eq,
+                        operator.add, operator.mul, operator.pow, builtins.min, builtins.max])
+def python_callable(request):
+    return request.param
+
+
+def test_python_callable_and_sympy_function_conversion2(python_callable):
+    assert sympy_function_to_python_callable(python_callable_to_sympy_function(python_callable)) == python_callable
+
+
 def test_sympy_function_application():
     constant_one = SymPyExpression.new_constant(1)
     constant_two = SymPyExpression.new_constant(2)
-    add_func = SymPyExpression.new_constant(operator.add)
+    int_to_int_to_int = BasicConstant(FunctionType([int, int], int))
+    add_func = SymPyExpression.new_constant(operator.add, int_to_int_to_int)
     fa = SymPyExpression.new_function_application(add_func, [constant_one, constant_two])
 
     assert fa.subexpressions[0] == add_func
@@ -140,11 +171,39 @@ def test_sympy_function_application():
     assert fa2 == SymPyExpression.new_function_application(
         add_func, [constant_two, SymPyExpression.new_function_application(add_func, [constant_two, constant_two])])
 
-    fa3 = fa.set(0, SymPyExpression.new_constant(operator.mul))
-    assert fa3 == SymPyExpression.new_function_application(SymPyExpression.new_constant(operator.mul),
+    # some new type test.
+    assert fa2.subexpressions[0].type == int_to_int_to_int
+    assert fa2.subexpressions[1].type == new_type(int)
+    assert fa2.subexpressions[2].type == new_type(int)  # return type
+    assert fa2.subexpressions[2].function.type == int_to_int_to_int  # return type
+    assert fa2.subexpressions[2].subexpressions[1].type == new_type(int)
+    assert fa2.subexpressions[2].subexpressions[2].type == new_type(int)
+
+    fa3 = fa.set(0, SymPyExpression.new_constant(operator.mul, int_to_int_to_int))
+    assert fa3 == SymPyExpression.new_function_application(SymPyExpression.new_constant(operator.mul,
+                                                                                        int_to_int_to_int),
                                                            [constant_one, constant_two])
     assert fa == SymPyExpression.new_function_application(add_func, [constant_one, constant_two])
-    fa6 = fa.set(1, SymPyExpression.new_variable("a"))
-    assert fa6 == SymPyExpression.new_function_application(add_func, [SymPyExpression.new_variable("a"), constant_two])
+    fa6 = fa.set(1, SymPyExpression.new_variable("a", new_type(int)))
+    assert fa6 == SymPyExpression.new_function_application(add_func, [SymPyExpression.new_variable("a", new_type(int)),
+                                                                      constant_two])
     with pytest.raises(IndexError):
         fa2.set(3, constant_one)
+
+    # a trickier one: add can be of different types.
+    int_to_float_to_float = BasicConstant(FunctionType([int, float], float))
+    float_to_float_to_float = BasicConstant(FunctionType([float, float], float))
+    mixed_add_func = SymPyExpression.new_constant(operator.add, int_to_float_to_float)
+    float_add_func = SymPyExpression.new_constant(operator.add, float_to_float_to_float)
+    constant_two_f = SymPyExpression.new_constant(2.0)
+    mixed_adds = SymPyExpression.new_function_application(
+        mixed_add_func, [constant_two,
+                         SymPyExpression.new_function_application(float_add_func,
+                                                                  [constant_two_f, constant_two_f])])
+    assert mixed_adds.type == new_type(float)
+    assert mixed_adds.subexpressions[0].type == int_to_float_to_float
+    assert mixed_adds.subexpressions[1].type == new_type(int)
+    assert mixed_adds.subexpressions[2].type == new_type(float)
+    assert mixed_adds.subexpressions[2].function.type == float_to_float_to_float
+    assert mixed_adds.subexpressions[2].subexpressions[1].type == new_type(float)
+    assert mixed_adds.subexpressions[2].subexpressions[2].type == new_type(float)

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -3,11 +3,17 @@ import operator
 import sympy
 import builtins
 
-from neuralpp.symbolic.basic_expression import BasicVariable, BasicConstant, BasicFunctionApplication
+from neuralpp.symbolic.expression import FunctionType
+from neuralpp.symbolic.basic_expression import BasicVariable, BasicConstant, BasicFunctionApplication, new_type
 from neuralpp.symbolic.basic_interpreter import BasicInterpreter
 from neuralpp.symbolic.sympy_expression import SymPyVariable, SymPyConstant, SymPyFunctionApplication, \
-    SymPyExpression, is_sympy_value
+    SymPyExpression
 from neuralpp.symbolic.sympy_interpreter import SymPyInterpreter
+
+
+int_to_int_to_int = BasicConstant(FunctionType([int, int], int))
+int_to_int_to_bool = BasicConstant(FunctionType([int, int], bool))
+bool_to_bool_to_bool = BasicConstant(FunctionType([bool, bool], bool))
 
 
 def test_basic_interpreter():
@@ -15,7 +21,7 @@ def test_basic_interpreter():
     bi = BasicInterpreter()
 
     # cannot evaluate variable
-    a = BasicVariable("a")
+    a = BasicVariable("a", new_type(int))
     with pytest.raises(AttributeError):
         bi.eval(a, true_context)
 
@@ -24,22 +30,22 @@ def test_basic_interpreter():
     assert bi.eval(one, true_context) == 1
 
     # lambda as a function
-    lambda_add = BasicConstant(lambda x, y: x + y)
+    lambda_add = BasicConstant(lambda x, y: x + y, int_to_int_to_int)
     add_one_to_one = BasicFunctionApplication(lambda_add, [one, one])
     assert bi.eval(add_one_to_one, true_context) == 2
 
-    python_divide = BasicConstant(lambda x, y: x / y)
+    python_divide = BasicConstant(lambda x, y: x / y, int_to_int_to_int)
     divide_by_zero = BasicFunctionApplication(python_divide, [one, BasicConstant(0)])
     with pytest.raises(ZeroDivisionError):
         bi.eval(divide_by_zero, true_context)
 
     # operator
-    operator_add = BasicConstant(operator.add)
+    operator_add = BasicConstant(operator.add, int_to_int_to_int)
     built_in_add_one_to_two = BasicFunctionApplication(operator_add, [one, BasicConstant(2)])
     assert bi.eval(built_in_add_one_to_two, true_context) == 3
 
     # uninterpreted function
-    uninterpreted_func = BasicVariable("func")
+    uninterpreted_func = BasicVariable("func", int_to_int_to_int)
     uninterpreted_application = BasicFunctionApplication(uninterpreted_func, [one])
     with pytest.raises(AttributeError):
         bi.eval(uninterpreted_application, true_context)
@@ -49,11 +55,20 @@ def test_basic_interpreter():
     assert bi.eval(nested_add, true_context) == 3
 
 
+def boolean_function_of_arity(arity: int) -> BasicConstant:
+    return BasicConstant(FunctionType([bool for i in range(arity)], bool))
+
+
 def dict_to_sympy_context(kv_map: dict) -> SymPyExpression:
     result = sympy.S.true
+    type_dict = {}
     for k, v in kv_map.items():
-        result = sympy.And(result, sympy.Eq(sympy.symbols(k), v, evaluate=False))
-    return SymPyFunctionApplication(result)
+        symbol = sympy.symbols(k)
+        eq_expression = sympy.Eq(symbol, v, evaluate=False)
+        result = sympy.And(result, eq_expression)
+        type_dict[symbol] = new_type(int)  # it's fine for test, we only use int
+        type_dict[eq_expression] = int_to_int_to_bool
+    return SymPyFunctionApplication(result, type_dict, boolean_function_of_arity(len(result.args)))
 
 
 def test_sympy_interpreter():
@@ -65,57 +80,69 @@ def test_sympy_interpreter():
     assert si.eval(one, true_context) == 1
 
     # operator
-    operator_add = BasicConstant(operator.add)
+    operator_add = BasicConstant(operator.add, int_to_int_to_int)
     two = SymPyConstant(sympy.Integer(2))
     add_one_to_two = SymPyExpression.new_function_application(operator_add, [one, two])
     assert si.eval(add_one_to_two, true_context) == 3
 
     # cannot evaluate variable
-    a = SymPyVariable(sympy.symbols("a"))
+    a = SymPyVariable(sympy.symbols("a"), new_type(int))
     with pytest.raises(RuntimeError):
         si.eval(a, true_context)
 
     # more interesting cases where there is a context
     x, y, z = sympy.symbols("x y z")
-    assert si.eval(SymPyFunctionApplication(x * 3), SymPyFunctionApplication(sympy.Eq(x, 10, evaluate=False))) == 30
+    assert si.eval(SymPyFunctionApplication(x * 3, {x: new_type(int)}, int_to_int_to_int),
+                   SymPyFunctionApplication(sympy.Eq(x, 10, evaluate=False), {x: new_type(int)}, int_to_int_to_bool)) \
+           == 30
 
     dict1 = {"x": 3, "y": 5}
-    assert si.eval(SymPyFunctionApplication(x * y), dict_to_sympy_context(dict1)) == 15
+    assert si.eval(SymPyFunctionApplication(x * y, {x: new_type(int), y: new_type(int)}, int_to_int_to_int),
+                   dict_to_sympy_context(dict1)) == 15
 
     dict2 = {"x": 3, "y": 5, "z": 100}
-    assert si.eval(SymPyFunctionApplication(x * y + z), dict_to_sympy_context(dict2)) == 115
+    assert si.eval(SymPyFunctionApplication(x * y + z, {x: new_type(int), y: new_type(int), z: new_type(int),
+                                                        x*y: int_to_int_to_int},
+                                            int_to_int_to_int),
+                   dict_to_sympy_context(dict2)) == 115
 
     # test operators
-    operator_mul = BasicConstant(operator.mul)
+    operator_mul = BasicConstant(operator.mul, int_to_int_to_int)
     two_times_two = SymPyExpression.new_function_application(operator_mul, [two, two])
     assert si.eval(two_times_two, true_context) == 4
 
-    operator_pow = BasicConstant(operator.pow)
+    operator_pow = BasicConstant(operator.pow, int_to_int_to_int)
     three = SymPyConstant(sympy.Integer(3))
     two_to_the_third = SymPyExpression.new_function_application(operator_pow, [two, three])
     assert si.eval(two_to_the_third, true_context) == 8
 
-    operator_and = BasicConstant(operator.__and__)
+    operator_and = BasicConstant(operator.__and__, bool_to_bool_to_bool)
     true = SymPyConstant(sympy.S.true)
     false = SymPyConstant(sympy.S.false)
-    true_and_false = SymPyExpression.new_function_application(operator_and, [true, false])
-    assert not si.eval(true_and_false, true_context)
+    with pytest.raises(TypeError):
+        # we cannot do this because there's no way to prevent SymPy to evaluate And(True,False)
+        true_and_false = SymPyExpression.new_function_application(operator_and, [true, false])
+    # even if we specify evaluate=False, it still evaluates.
+    assert not sympy.And(sympy.S.true, sympy.S.false, evaluate=False)
 
-    true_or_false = SymPyExpression.new_function_application(BasicConstant(operator.__or__), [true, false])
-    assert si.eval(true_or_false, true_context)
-
+    # it's the case for or
+    with pytest.raises(TypeError):
+        true_or_false = SymPyExpression.new_function_application(BasicConstant(operator.__or__), [true, false])
+    # but not the case for "not" (for sympy 1.10.1, wonder if it's a bug?)
     not_true = SymPyExpression.new_function_application(BasicConstant(operator.__not__), [true])
     assert not si.eval(not_true, true_context)
 
-    one_le_one = SymPyExpression.new_function_application(BasicConstant(operator.le), [one, one])
+    one_le_one = SymPyExpression.new_function_application(BasicConstant(operator.le, int_to_int_to_bool), [one, one])
     assert si.eval(one_le_one, true_context)
 
-    one_lt_one = SymPyExpression.new_function_application(BasicConstant(operator.lt), [one, one])
+    one_lt_one = SymPyExpression.new_function_application(BasicConstant(operator.lt, int_to_int_to_bool), [one, one])
     assert not si.eval(one_lt_one, true_context)
 
-    max_of_one_three = SymPyExpression.new_function_application(BasicConstant(builtins.max), [one, three])
+    max_of_one_three = SymPyExpression.new_function_application(BasicConstant(builtins.max, int_to_int_to_int),
+                                                                [one, three])
     assert si.eval(max_of_one_three, true_context) == 3
 
-    min_of_three_five = SymPyExpression.new_function_application(BasicConstant(builtins.min),
-                                                                 [SymPyVariable(x), SymPyVariable(y)])
+    min_of_three_five = SymPyExpression.new_function_application(BasicConstant(builtins.min, int_to_int_to_int),
+                                                                 [SymPyVariable(x, new_type(int)),
+                                                                  SymPyVariable(y, new_type(int))])
     assert si.eval(min_of_three_five, dict_to_sympy_context(dict1)) == 3

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -3,60 +3,59 @@ import operator
 import sympy
 import builtins
 
-from neuralpp.symbolic.expression import FunctionType
-from neuralpp.symbolic.basic_expression import BasicVariable, BasicConstant, BasicFunctionApplication, new_type
+from typing import Callable
+from neuralpp.symbolic.basic_expression import BasicVariable, BasicConstant, BasicFunctionApplication
 from neuralpp.symbolic.basic_interpreter import BasicInterpreter
 from neuralpp.symbolic.sympy_expression import SymPyVariable, SymPyConstant, SymPyFunctionApplication, \
     SymPyExpression
 from neuralpp.symbolic.sympy_interpreter import SymPyInterpreter
 
 
-int_to_int_to_int = BasicConstant(FunctionType([int, int], int))
-int_to_int_to_bool = BasicConstant(FunctionType([int, int], bool))
-bool_to_bool_to_bool = BasicConstant(FunctionType([bool, bool], bool))
+int_to_int_to_int = Callable[[int, int], int]
+int_to_int_to_bool = Callable[[int, int], bool]
+bool_to_bool_to_bool = Callable[[bool, bool], bool]
 
 
 def test_basic_interpreter():
-    true_context = BasicConstant(True)
     bi = BasicInterpreter()
 
     # cannot evaluate variable
-    a = BasicVariable("a", new_type(int))
+    a = BasicVariable("a", int)
     with pytest.raises(AttributeError):
-        bi.eval(a, true_context)
+        bi.eval(a)
 
     # trivial case to evaluate constant
     one = BasicConstant(1)
-    assert bi.eval(one, true_context) == 1
+    assert bi.eval(one) == 1
 
     # lambda as a function
     lambda_add = BasicConstant(lambda x, y: x + y, int_to_int_to_int)
     add_one_to_one = BasicFunctionApplication(lambda_add, [one, one])
-    assert bi.eval(add_one_to_one, true_context) == 2
+    assert bi.eval(add_one_to_one) == 2
 
     python_divide = BasicConstant(lambda x, y: x / y, int_to_int_to_int)
     divide_by_zero = BasicFunctionApplication(python_divide, [one, BasicConstant(0)])
     with pytest.raises(ZeroDivisionError):
-        bi.eval(divide_by_zero, true_context)
+        bi.eval(divide_by_zero)
 
     # operator
     operator_add = BasicConstant(operator.add, int_to_int_to_int)
     built_in_add_one_to_two = BasicFunctionApplication(operator_add, [one, BasicConstant(2)])
-    assert bi.eval(built_in_add_one_to_two, true_context) == 3
+    assert bi.eval(built_in_add_one_to_two) == 3
 
     # uninterpreted function
     uninterpreted_func = BasicVariable("func", int_to_int_to_int)
     uninterpreted_application = BasicFunctionApplication(uninterpreted_func, [one])
     with pytest.raises(AttributeError):
-        bi.eval(uninterpreted_application, true_context)
+        bi.eval(uninterpreted_application)
 
     # a nested function application example
     nested_add = BasicFunctionApplication(lambda_add, [one, add_one_to_one])
-    assert bi.eval(nested_add, true_context) == 3
+    assert bi.eval(nested_add) == 3
 
 
 def boolean_function_of_arity(arity: int) -> BasicConstant:
-    return BasicConstant(FunctionType([bool for i in range(arity)], bool))
+    return Callable[[bool for i in range(arity)], bool]
 
 
 def dict_to_sympy_context(kv_map: dict) -> SymPyExpression:
@@ -66,42 +65,41 @@ def dict_to_sympy_context(kv_map: dict) -> SymPyExpression:
         symbol = sympy.symbols(k)
         eq_expression = sympy.Eq(symbol, v, evaluate=False)
         result = sympy.And(result, eq_expression)
-        type_dict[symbol] = new_type(int)  # it's fine for test, we only use int
+        type_dict[symbol] = int  # it's fine for test, we only use int
         type_dict[eq_expression] = int_to_int_to_bool
     return SymPyFunctionApplication(result, type_dict, boolean_function_of_arity(len(result.args)))
 
 
 def test_sympy_interpreter():
-    true_context = SymPyConstant(sympy.S.true)
     si = SymPyInterpreter()
 
     # trivial case to evaluate constant
     one = SymPyConstant(sympy.Integer(1))
-    assert si.eval(one, true_context) == 1
+    assert si.eval(one) == 1
 
     # operator
     operator_add = BasicConstant(operator.add, int_to_int_to_int)
     two = SymPyConstant(sympy.Integer(2))
     add_one_to_two = SymPyExpression.new_function_application(operator_add, [one, two])
-    assert si.eval(add_one_to_two, true_context) == 3
+    assert si.eval(add_one_to_two) == 3
 
     # cannot evaluate variable
-    a = SymPyVariable(sympy.symbols("a"), new_type(int))
+    a = SymPyVariable(sympy.symbols("a"), int)
     with pytest.raises(RuntimeError):
-        si.eval(a, true_context)
+        si.eval(a)
 
     # more interesting cases where there is a context
     x, y, z = sympy.symbols("x y z")
-    assert si.eval(SymPyFunctionApplication(x * 3, {x: new_type(int)}, int_to_int_to_int),
-                   SymPyFunctionApplication(sympy.Eq(x, 10, evaluate=False), {x: new_type(int)}, int_to_int_to_bool)) \
+    assert si.eval(SymPyFunctionApplication(x * 3, {x: int}, int_to_int_to_int),
+                   SymPyFunctionApplication(sympy.Eq(x, 10, evaluate=False), {x: int}, int_to_int_to_bool)) \
            == 30
 
     dict1 = {"x": 3, "y": 5}
-    assert si.eval(SymPyFunctionApplication(x * y, {x: new_type(int), y: new_type(int)}, int_to_int_to_int),
+    assert si.eval(SymPyFunctionApplication(x * y, {x: int, y: int}, int_to_int_to_int),
                    dict_to_sympy_context(dict1)) == 15
 
     dict2 = {"x": 3, "y": 5, "z": 100}
-    assert si.eval(SymPyFunctionApplication(x * y + z, {x: new_type(int), y: new_type(int), z: new_type(int),
+    assert si.eval(SymPyFunctionApplication(x * y + z, {x: int, y: int, z: int,
                                                         x*y: int_to_int_to_int},
                                             int_to_int_to_int),
                    dict_to_sympy_context(dict2)) == 115
@@ -109,40 +107,40 @@ def test_sympy_interpreter():
     # test operators
     operator_mul = BasicConstant(operator.mul, int_to_int_to_int)
     two_times_two = SymPyExpression.new_function_application(operator_mul, [two, two])
-    assert si.eval(two_times_two, true_context) == 4
+    assert si.eval(two_times_two) == 4
 
     operator_pow = BasicConstant(operator.pow, int_to_int_to_int)
     three = SymPyConstant(sympy.Integer(3))
     two_to_the_third = SymPyExpression.new_function_application(operator_pow, [two, three])
-    assert si.eval(two_to_the_third, true_context) == 8
+    assert si.eval(two_to_the_third) == 8
 
-    operator_and = BasicConstant(operator.__and__, bool_to_bool_to_bool)
+    operator_and = BasicConstant(operator.and_, bool_to_bool_to_bool)
     true = SymPyConstant(sympy.S.true)
     false = SymPyConstant(sympy.S.false)
     with pytest.raises(TypeError):
         # we cannot do this because there's no way to prevent SymPy to evaluate And(True,False)
-        true_and_false = SymPyExpression.new_function_application(operator_and, [true, false])
+        SymPyExpression.new_function_application(operator_and, [true, false])
     # even if we specify evaluate=False, it still evaluates.
     assert not sympy.And(sympy.S.true, sympy.S.false, evaluate=False)
 
     # it's the case for or
     with pytest.raises(TypeError):
-        true_or_false = SymPyExpression.new_function_application(BasicConstant(operator.__or__), [true, false])
+        SymPyExpression.new_function_application(BasicConstant(operator.or_, bool_to_bool_to_bool), [true, false])
     # but not the case for "not" (for sympy 1.10.1, wonder if it's a bug?)
-    not_true = SymPyExpression.new_function_application(BasicConstant(operator.__not__), [true])
-    assert not si.eval(not_true, true_context)
+    not_true = SymPyExpression.new_function_application(BasicConstant(operator.not_), [true])
+    assert not si.eval(not_true)
 
     one_le_one = SymPyExpression.new_function_application(BasicConstant(operator.le, int_to_int_to_bool), [one, one])
-    assert si.eval(one_le_one, true_context)
+    assert si.eval(one_le_one)
 
     one_lt_one = SymPyExpression.new_function_application(BasicConstant(operator.lt, int_to_int_to_bool), [one, one])
-    assert not si.eval(one_lt_one, true_context)
+    assert not si.eval(one_lt_one)
 
     max_of_one_three = SymPyExpression.new_function_application(BasicConstant(builtins.max, int_to_int_to_int),
                                                                 [one, three])
-    assert si.eval(max_of_one_three, true_context) == 3
+    assert si.eval(max_of_one_three) == 3
 
     min_of_three_five = SymPyExpression.new_function_application(BasicConstant(builtins.min, int_to_int_to_int),
-                                                                 [SymPyVariable(x, new_type(int)),
-                                                                  SymPyVariable(y, new_type(int))])
+                                                                 [SymPyVariable(x, int),
+                                                                  SymPyVariable(y, int)])
     assert si.eval(min_of_three_five, dict_to_sympy_context(dict1)) == 3

--- a/neuralpp/util/util.py
+++ b/neuralpp/util/util.py
@@ -622,11 +622,11 @@ def check_consistency_of_two_dicts(dict1: Dict, dict2: Dict):
             raise ValueError(f"inconsistent dicts on {key}: {dict1[key]} and {dict2[key]}.")
 
 
-def consistently_update_dict(dict1: Dict, dict2: Dict):
+def update_consistent_dict(dict1: Dict, dict2: Dict):
     """
     Assumes two dictionaries are consistent (i.e., for all k, if k in dict1 and k in dict2: dict1[k] == dict2[k])
-    E.g., suppose dict1 = {1:2, 2:3}, after consistently_update_dict(dict1, {2:3, 3:5}), dict1 = {1:2, 2:3, 3:5};
-          consistently_update_dict({1:2, 2:3}, {2:4, 3:5}) raises error.
+    E.g., suppose dict1 = {1:2, 2:3}, after update_consistent_dict(dict1, {2:3, 3:5}), dict1 = {1:2, 2:3, 3:5};
+          update_consistent_dict({1:2, 2:3}, {2:4, 3:5}) raises error.
     """
     check_consistency_of_two_dicts(dict1, dict2)
     dict1.update(dict2)

--- a/neuralpp/util/util.py
+++ b/neuralpp/util/util.py
@@ -2,7 +2,7 @@ import math
 import os
 import random
 from itertools import tee
-from typing import List, Iterable, Any, Set, TypeVar
+from typing import List, Iterable, Any, Set, TypeVar, Dict
 
 import torch
 
@@ -613,3 +613,20 @@ def list_for_each(
         if post_index_result is not None:
             post_index_result(index, result)
     return result
+
+
+def check_consistency_of_two_dicts(dict1: Dict, dict2: Dict):
+    intersection_keys = dict1.keys() & dict2.keys()
+    for key in intersection_keys:
+        if dict1[key] != dict2[key]:
+            raise ValueError(f"inconsistent dicts on {key}: {dict1[key]} and {dict2[key]}.")
+
+
+def consistently_update_dict(dict1: Dict, dict2: Dict):
+    """
+    Assumes two dictionaries are consistent (i.e., for all k, if k in dict1 and k in dict2: dict1[k] == dict2[k])
+    E.g., suppose dict1 = {1:2, 2:3}, after consistently_update_dict(dict1, {2:3, 3:5}), dict1 = {1:2, 2:3, 3:5};
+          consistently_update_dict({1:2, 2:3}, {2:4, 3:5}) raises error.
+    """
+    check_consistency_of_two_dicts(dict1, dict2)
+    dict1.update(dict2)


### PR DESCRIPTION
1. added a new property type for `Expression`; 
2. for `SymPyExpression`, an additional dict is used to keep track of all sub-literals (variables and function), since a sympy object does not keep track of these;
3. fixed all affected unit tests, and added some new unit tests