### PR TITLE
Enhanced interface for context

### DIFF
--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -110,6 +110,10 @@ class TrueContext(BasicConstant, Context):
     def unsatisfiable(self) -> bool:
         return False
 
+    @property
+    def satisfiability_is_known(self) -> bool:
+        return True
+
     def __init__(self):
         BasicConstant.__init__(self, True, bool)
 
@@ -121,6 +125,10 @@ class FalseContext(BasicConstant, Context):
 
     @property
     def unsatisfiable(self) -> bool:
+        return True
+
+    @property
+    def satisfiability_is_known(self) -> bool:
         return True
 
     def __init__(self):

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -383,6 +383,11 @@ class Context(Expression, ABC):
         pass
 
     @property
+    @abstractmethod
+    def satisfiability_is_known(self) -> bool:
+        pass
+
+    @property
     def and_priority(self) -> int:
         """ So that conjoining anything with a context object `c` causes c.__and__ to be called. """
         return 1

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -64,7 +64,7 @@ def _infer_sympy_function_type(sympy_object: sympy.Basic, type_dict: Dict[sympy.
                                       [_infer_sympy_object_type(arg, type_dict) for arg in sympy_object.args])
 
 
-sympy_Sub = sympy.Lambda((abc.x, abc.y), abc.x-abc.y)
+sympy_Sub = sympy.Lambda((abc.x, abc.y), abc.x - abc.y)
 sympy_Neg = sympy.Lambda((abc.x,), -abc.x)  # "lambda x: (-1)*x"
 # Refer to sympy_simplification_test:test_unevaluate() for this design that uses sympy.Lambda()
 python_callable_and_sympy_function_relation = [
@@ -318,26 +318,41 @@ class SymPyFunctionApplication(SymPyExpression, FunctionApplication):
 
 
 def _context_to_variable_value_dict_helper(context: FunctionApplication,
-                                           variable_to_value: Dict[str, Any]) -> Dict[str, Any]:
+                                           variable_to_value: Dict[str, Any],
+                                           unknown: bool = False,
+                                           unsatisfiable: bool = False,
+                                           ) -> Tuple[Dict[str, Any], bool, bool]:
     """
     variable_to_value: the mutable argument also serves as a return value.
-    If the context has multiple assignments (e.g., x==3 and x==5), we just pick the last one.
-    This does not violate our specification, since ex falso quodlibet, "from falsehood, anything follows".
+    By default, we assume the context's satisfiability can be known and is True.
+    If the context has multiple assignments (e.g., x==3 and x==5), the context is unsatisfiable.
+    If the context is anything other than a conjunction of equalities, the context is unknown.
     """
     match context:
         case FunctionApplication(function=Constant(value=operator.and_), arguments=arguments):
             # the conjunctive case
             for sub_context in arguments:
-                variable_to_value = _context_to_variable_value_dict_helper(sub_context, variable_to_value)
+                variable_to_value, unknown, unsatisfiable = \
+                    _context_to_variable_value_dict_helper(sub_context, variable_to_value, unknown, unsatisfiable)
         case FunctionApplication(function=Constant(value=operator.eq),
-                                 arguments=[Variable(name=lhs), Constant(value=rhs)]):
+                                 arguments=[Variable(name=variable), Constant(value=value)]) | \
+                FunctionApplication(function=Constant(value=operator.eq),
+                                    arguments=[Constant(value=value), Variable(name=variable)]):
             # the leaf case
-            variable_to_value[lhs] = rhs
-        # all other cases are ignored
-    return variable_to_value
+            if variable in variable_to_value and variable_to_value[variable] != value:
+                unsatisfiable = True
+            variable_to_value[variable] = value
+        # all other cases makes the satisfiability unknown
+        case _:
+            unknown = True
+    return variable_to_value, unknown, unsatisfiable
 
 
-def _context_to_variable_value_dict(context: FunctionApplication) -> Dict[str, Any]:
+def _context_to_variable_value_dict(context: FunctionApplication) -> Tuple[Dict[str, Any], bool, bool]:
+    """
+    Returns a dictionary, and two booleans: first indicating whether its satisfiability is unknown, second indicating
+    whether it is unsatisfiable (if its satisfiability is known)
+    """
     return _context_to_variable_value_dict_helper(context, {})
 
 
@@ -345,12 +360,26 @@ class SymPyContext(SymPyFunctionApplication, Context):
     """
     SymPyContext is just a SymPyFunctionApplication, which always raises when asked for satisfiability
     since we don't know.
-    We create a dictionary from the function application at the first time `dict()` property is called. """
+    We create a dictionary from the function application at initialization. """
+    def __init__(self, sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, ExpressionType]):
+        SymPyFunctionApplication.__init__(self, sympy_object, type_dict)
+        self._dict, self._unknown, self._unsatisfiable = _context_to_variable_value_dict(self)
+        if self._unsatisfiable:
+            # if unsat, looking up dict for value does not make sense, as any value can be detailed
+            self._dict = {}
+
     @property
     def unsatisfiable(self) -> bool:
-        raise Context.UnknownError()
+        if self._unknown:
+            raise Context.UnknownError()
+        else:
+            return self._unsatisfiable
 
-    @cached_property
+    @property
     def dict(self) -> Dict[str, Any]:
-        return _context_to_variable_value_dict(self)
+        """ User should not write to the return value. """
+        return self._dict
 
+    @property
+    def satisfiability_is_known(self) -> bool:
+        return not self._unknown

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -230,3 +230,20 @@ def test_sympy_interpreter_simplify_operator_overload():
     y_2_context = dict_to_sympy_context({"y": 2})
     print(f"y=2 context:{y_2_context}")
     assert si.simplify(b_x_plus_y, y_2_context).sympy_object == x + 2
+
+
+def test_sympy_context():
+    y_2_context = dict_to_sympy_context({"y": 2})
+    assert y_2_context.satisfiability_is_known
+    assert not y_2_context.unsatisfiable
+
+    x = sympy.symbols("x")
+    unsat_context = SymPyContext(sympy.Eq(x, 3) & sympy.Eq(x, 2), {x: int})
+    assert unsat_context.satisfiability_is_known
+    assert unsat_context.unsatisfiable
+    assert unsat_context.dict == {}
+
+    unknown_context = SymPyContext(sympy.Eq(x, 3) & sympy.Gt(x, 2), {x: int})
+    assert not unknown_context.satisfiability_is_known
+    with pytest.raises(SymPyContext.UnknownError):
+        unknown_context.unsatisfiable


### PR DESCRIPTION
A context backed by a SMT solver can return three value when it is asked to check for satisfiability: `sat`, `unsat` and `unknown`. In designing the interface property `unsatisfiable` of our `Context`, we have a design choice:
1. to make `unsatisfiable` raise an `UnknownError` when the solver returns unknown. The pros: we maintain a boolean interface of "unsatisfiable" which is intuitive; the cons: library users needs to deal with the `UnknownError` exception and user code can be unnecessarily complicated because of that;
2. to make `unsatisfiable` return a value from {sat, unsat, unknown}. Pros: user code can be cleaner; cons: the three-value interface is less intuitive and not corresponding to the name (library users would expect `unsatisfiable` to return a boolean based on the name).

Decision:
Go with choice 1, but also introduce an interface property `satisfiability_is_known`, so that user code can check for `satisfiability_is_known` before ask for `unsatisfiable` and deals with unknown case in a more elegant way.