### PR TITLE
Conditional expression

### DIFF
--- a/neuralpp/symbolic/__init__.py
+++ b/neuralpp/symbolic/__init__.py
@@ -1,1 +1,1 @@
-from .functions import (cond,)
+from .functions import (conditional, )

--- a/neuralpp/symbolic/__init__.py
+++ b/neuralpp/symbolic/__init__.py
@@ -1,0 +1,1 @@
+from .functions import (cond,)

--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -6,6 +6,7 @@ from neuralpp.symbolic.expression import Expression, FunctionApplication, Variab
     VariableNotTypedError, ExpressionType, get_arithmetic_function_type_from_argument_types, Context
 from abc import ABC
 from typing import Any, List, Optional, Callable, Dict
+import neuralpp.symbolic.functions as functions
 
 
 class AmbiguousTypeError(TypeError, ValueError):
@@ -48,6 +49,13 @@ def infer_python_callable_type(python_callable: Callable, argument_types: List[E
             if len(argument_types) != 1:
                 raise TypeError(f"Neg only expects one argument.")
             return Callable[argument_types, argument_types[0]]
+        # if then else
+        case functions.cond:
+            if argument_types is None:
+                raise AmbiguousTypeError(python_callable)
+            if len(argument_types) != 3 or argument_types[0] != bool or argument_types[1] != argument_types[2]:
+                raise TypeError("Wrong conditional expression type.")
+            return Callable[argument_types, argument_types[1]]
         case _:
             raise ValueError(f"Python callable {python_callable} is not recognized.")
 

--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -89,7 +89,7 @@ class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):
     def atom(self) -> str:
         return self._atom
 
-    def __eq__(self, other) -> bool:
+    def syntactic_eq(self, other) -> bool:
         match other:
             case BasicAtomicExpression(base_type=other_base_type, atom=other_atom, type=other_type):
                 return other_base_type == self.base_type and self.type == other_type and self.atom == other_atom
@@ -165,9 +165,10 @@ class BasicFunctionApplication(BasicExpression, FunctionApplication):
     def number_of_arguments(self) -> int:
         return len(self.arguments)
 
-    def __eq__(self, other):
+    def syntactic_eq(self, other) -> bool:
         match other:
             case BasicFunctionApplication(function=function, arguments=arguments, type=other_type):
-                return self.subexpressions == [function] + arguments and self.type == other_type
+                return all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, [function] + arguments)) and \
+                       self.type == other_type
             case _:
                 return False

--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -50,7 +50,7 @@ def infer_python_callable_type(python_callable: Callable, argument_types: List[E
                 raise TypeError(f"Neg only expects one argument.")
             return Callable[argument_types, argument_types[0]]
         # if then else
-        case functions.cond:
+        case functions.conditional:
             if argument_types is None:
                 raise AmbiguousTypeError(python_callable)
             if len(argument_types) != 3 or argument_types[0] != bool or argument_types[1] != argument_types[2]:

--- a/neuralpp/symbolic/constants.py
+++ b/neuralpp/symbolic/constants.py
@@ -1,0 +1,105 @@
+import fractions
+import operator
+from typing import Callable, Type
+from .basic_expression import BasicConstant
+from .functions import conditional
+
+
+def if_then_else(type_: Type):
+    return BasicConstant(conditional, Callable[[bool, type_, type_], type_])
+
+
+bool_if_then_else = if_then_else(bool)
+int_if_then_else = if_then_else(int)
+float_if_then_else = if_then_else(float)
+real_if_then_else = if_then_else(fractions.Fraction)
+
+
+def add(type_: Type):
+    return BasicConstant(operator.add, Callable[[type_, type_], type_])
+
+
+int_add = add(int)
+float_add = add(float)
+real_add = add(fractions.Fraction)
+
+
+def multiply(type_: Type):
+    return BasicConstant(operator.mul, Callable[[type_, type_], type_])
+
+
+int_multiply = multiply(int)
+float_multiply = multiply(float)
+real_multiply = multiply(fractions.Fraction)
+
+
+def minus(type_: Type):
+    return BasicConstant(operator.sub, Callable[[type_, type_], type_])
+
+
+int_minus = minus(int)
+float_minus = minus(float)
+real_minus = minus(fractions.Fraction)
+
+
+def div(type_: Type):
+    return BasicConstant(operator.truediv, Callable[[type_, type_], type_])
+
+
+int_div = div(int)
+float_div = div(float)
+real_div = div(fractions.Fraction)
+
+
+def lt(type_: Type):
+    return BasicConstant(operator.lt, Callable[[type_, type_], bool])
+
+
+int_lt = lt(int)
+float_lt = lt(float)
+real_lt = lt(fractions.Fraction)
+
+
+def le(type_: Type):
+    return BasicConstant(operator.le, Callable[[type_, type_], bool])
+
+
+int_le = le(int)
+float_le = le(float)
+real_le = le(fractions.Fraction)
+
+
+def gt(type_: Type):
+    return BasicConstant(operator.gt, Callable[[type_, type_], bool])
+
+
+int_gt = gt(int)
+float_gt = gt(float)
+real_gt = gt(fractions.Fraction)
+
+
+def ge(type_: Type):
+    return BasicConstant(operator.ge, Callable[[type_, type_], bool])
+
+
+int_ge = ge(int)
+float_ge = ge(float)
+real_ge = ge(fractions.Fraction)
+
+
+def eq(type_: Type):
+    return BasicConstant(operator.eq, Callable[[type_, type_], bool])
+
+
+int_eq = eq(int)
+float_eq = eq(float)
+real_eq = eq(fractions.Fraction)
+
+
+def ne(type_: Type):
+    return BasicConstant(operator.ne, Callable[[type_, type_], bool])
+
+
+int_ne = ne(int)
+float_ne = ne(float)
+real_ne = ne(fractions.Fraction)

--- a/neuralpp/symbolic/constants.py
+++ b/neuralpp/symbolic/constants.py
@@ -3,9 +3,10 @@ import operator
 from typing import Callable, Type, Any
 from .basic_expression import BasicConstant
 from .functions import conditional
+from .expression import Expression
 
 
-def if_then_else_function(type_: Type):
+def if_then_else_function(type_: Type) -> Expression:
     return BasicConstant(conditional, Callable[[bool, type_, type_], type_])
 
 
@@ -15,7 +16,7 @@ float_if_then_else_function = if_then_else_function(float)
 real_if_then_else_function = if_then_else_function(fractions.Fraction)
 
 
-def if_then_else(if_: Any, then_: Any, else_: Any):
+def if_then_else(if_: Any, then_: Any, else_: Any) -> Expression:
     if not type(then_) == type(else_):
         raise TypeError(f"Expect then-clause ({type(then_)}) and else-clause ({type(else_)}) have the same type.")
     match then_:
@@ -31,7 +32,7 @@ def if_then_else(if_: Any, then_: Any, else_: Any):
             raise TypeError(f"Unrecognized type {type(then_)}.")
 
 
-def add(type_: Type):
+def add(type_: Type) -> Expression:
     return BasicConstant(operator.add, Callable[[type_, type_], type_])
 
 
@@ -40,7 +41,7 @@ float_add = add(float)
 real_add = add(fractions.Fraction)
 
 
-def multiply(type_: Type):
+def multiply(type_: Type) -> Expression:
     return BasicConstant(operator.mul, Callable[[type_, type_], type_])
 
 
@@ -49,7 +50,7 @@ float_multiply = multiply(float)
 real_multiply = multiply(fractions.Fraction)
 
 
-def minus(type_: Type):
+def minus(type_: Type) -> Expression:
     return BasicConstant(operator.sub, Callable[[type_, type_], type_])
 
 
@@ -58,7 +59,7 @@ float_minus = minus(float)
 real_minus = minus(fractions.Fraction)
 
 
-def div(type_: Type):
+def div(type_: Type) -> Expression:
     return BasicConstant(operator.truediv, Callable[[type_, type_], type_])
 
 
@@ -67,7 +68,7 @@ float_div = div(float)
 real_div = div(fractions.Fraction)
 
 
-def lt(type_: Type):
+def lt(type_: Type) -> Expression:
     return BasicConstant(operator.lt, Callable[[type_, type_], bool])
 
 
@@ -76,7 +77,7 @@ float_lt = lt(float)
 real_lt = lt(fractions.Fraction)
 
 
-def le(type_: Type):
+def le(type_: Type) -> Expression:
     return BasicConstant(operator.le, Callable[[type_, type_], bool])
 
 
@@ -85,7 +86,7 @@ float_le = le(float)
 real_le = le(fractions.Fraction)
 
 
-def gt(type_: Type):
+def gt(type_: Type) -> Expression:
     return BasicConstant(operator.gt, Callable[[type_, type_], bool])
 
 
@@ -94,7 +95,7 @@ float_gt = gt(float)
 real_gt = gt(fractions.Fraction)
 
 
-def ge(type_: Type):
+def ge(type_: Type) -> Expression:
     return BasicConstant(operator.ge, Callable[[type_, type_], bool])
 
 
@@ -103,7 +104,7 @@ float_ge = ge(float)
 real_ge = ge(fractions.Fraction)
 
 
-def eq(type_: Type):
+def eq(type_: Type) -> Expression:
     return BasicConstant(operator.eq, Callable[[type_, type_], bool])
 
 
@@ -112,7 +113,7 @@ float_eq = eq(float)
 real_eq = eq(fractions.Fraction)
 
 
-def ne(type_: Type):
+def ne(type_: Type) -> Expression:
     return BasicConstant(operator.ne, Callable[[type_, type_], bool])
 
 

--- a/neuralpp/symbolic/constants.py
+++ b/neuralpp/symbolic/constants.py
@@ -1,18 +1,34 @@
 import fractions
 import operator
-from typing import Callable, Type
+from typing import Callable, Type, Any
 from .basic_expression import BasicConstant
 from .functions import conditional
 
 
-def if_then_else(type_: Type):
+def if_then_else_function(type_: Type):
     return BasicConstant(conditional, Callable[[bool, type_, type_], type_])
 
 
-bool_if_then_else = if_then_else(bool)
-int_if_then_else = if_then_else(int)
-float_if_then_else = if_then_else(float)
-real_if_then_else = if_then_else(fractions.Fraction)
+bool_if_then_else_function = if_then_else_function(bool)
+int_if_then_else_function = if_then_else_function(int)
+float_if_then_else_function = if_then_else_function(float)
+real_if_then_else_function = if_then_else_function(fractions.Fraction)
+
+
+def if_then_else(if_: Any, then_: Any, else_: Any):
+    if not type(then_) == type(else_):
+        raise TypeError(f"Expect then-clause ({type(then_)}) and else-clause ({type(else_)}) have the same type.")
+    match then_:
+        case bool():
+            return bool_if_then_else_function(if_, then_, else_)
+        case int():
+            return int_if_then_else_function(if_, then_, else_)
+        case float():
+            return float_if_then_else_function(if_, then_, else_)
+        case fractions.Fraction():
+            return real_if_then_else_function(if_, then_, else_)
+        case _:
+            raise TypeError(f"Unrecognized type {type(then_)}.")
 
 
 def add(type_: Type):

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -116,7 +116,7 @@ class Expression(ABC):
         return False
 
     @abstractmethod
-    def __eq__(self, other) -> bool:
+    def syntactic_eq(self, other) -> bool:
         pass
 
     @classmethod
@@ -294,8 +294,11 @@ class Expression(ABC):
     def __ge__(self, other) -> Expression:
         return self._new_binary_comparison(other, operator.ge)
 
-    # def __ne__(self, other) -> Expression:
-    #     return self._new_binary_comparison(other, operator.ne)
+    def __ne__(self, other) -> Expression:
+        return self._new_binary_comparison(other, operator.ne)
+
+    def __eq__(self, other) -> Expression:
+        return self._new_binary_comparison(other, operator.eq)
 
 
 class AtomicExpression(Expression, ABC):
@@ -314,7 +317,7 @@ class AtomicExpression(Expression, ABC):
         return []
 
     def replace(self, from_expression: Expression, to_expression: Expression) -> Expression:
-        if from_expression == self:
+        if from_expression.syntactic_eq(self):
             return to_expression
         else:
             return self
@@ -323,7 +326,7 @@ class AtomicExpression(Expression, ABC):
         raise IndexError(f"{type(self)} has no subexpressions, so you cannot set().")
 
     def contains(self, target: Expression) -> bool:
-        return self == target
+        return self.syntactic_eq(target)
 
 
 class Variable(AtomicExpression, ABC):
@@ -394,7 +397,7 @@ class FunctionApplication(Expression, ABC):
     def replace(self, from_expression: Expression, to_expression: Expression) -> Expression:
         # recursively do the replacement
         new_subexpressions = [
-            to_expression if e == from_expression else e.replace(from_expression, to_expression)
+            to_expression if e.syntactic_eq(from_expression) else e.replace(from_expression, to_expression)
             for e in self.subexpressions
         ]
         return self.new_function_application(new_subexpressions[0], new_subexpressions[1:])

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -256,8 +256,10 @@ class Expression(ABC):
         return self._new_binary_arithmetic(other, operator.mul, reverse=True)
 
     def __truediv__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.truediv)
+        return self._new_binary_arithmetic(other, operator.truediv)
 
+    def __rtruediv__(self, other: Any) -> Expression:
+        return self._new_binary_arithmetic(other, operator.truediv, reverse=True)
 
     def __sub__(self, other: Any) -> Expression:
         return self._new_binary_arithmetic(other, operator.sub)
@@ -303,6 +305,11 @@ class Expression(ABC):
 
     def __eq__(self, other) -> Expression:
         return self._new_binary_comparison(other, operator.eq)
+
+    def __call__(self, *args, **kwargs) -> Expression:
+        return self.new_function_application(self,
+                                             [arg if isinstance(arg, Expression) else self.new_constant(arg, None)
+                                              for arg in args])
 
 
 class AtomicExpression(Expression, ABC):

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -210,7 +210,16 @@ class Expression(ABC):
             raise TypeError(f"{self}'s function is not of function type.")
         return return_type_after_application(function_type, number_of_arguments)
 
-    def _new_binary_operation(self, other, operator_, function_type=None, reverse=False) -> Expression:
+    def _new_binary_arithmetic(self, other, operator_, function_type=None, reverse=False) -> Expression:
+        return self._new_binary_operation(other, operator_, function_type, reverse, arithmetic=True)
+
+    def _new_binary_boolean(self, other, operator_, reverse=False) -> Expression:
+        return self._new_binary_operation(other, operator_, Callable[[bool, bool], bool], reverse, arithmetic=False)
+
+    def _new_binary_comparison(self, other, operator_, function_type=None, reverse=False) -> Expression:
+        return self._new_binary_operation(other, operator_, function_type, reverse, arithmetic=False)
+
+    def _new_binary_operation(self, other, operator_, function_type=None, reverse=False, arithmetic=True) -> Expression:
         """
         Wrapper to make a binary operation in self's class. Tries to convert other to a Constant if it is not
         an Expression.
@@ -218,32 +227,39 @@ class Expression(ABC):
         By default, self is the 1st argument and other is the 2nd.
         If reverse is set to True, it is reversed, so e.g., if operator_ is `-` and reverse is True, then return
         `other - self`.
+        If `arithmetic` is True, the return type is inferred from the argument types. Otherwise, it's assumed to
+        be bool.
         """
         if not isinstance(other, Expression):
             other = self.new_constant(other, None)  # we can only try to create constant, for variable we need type.
         arguments = [self, other] if not reverse else [other, self]
         if function_type is None:
-            function_type = get_arithmetic_function_type_from_argument_types([arguments[0].type, arguments[1].type])
+            if arithmetic:
+                function_type = get_arithmetic_function_type_from_argument_types([arguments[0].type, arguments[1].type])
+            else:
+                if arguments[0].type != arguments[1].type:
+                    raise TypeError(f"Argument types mismatch: {arguments[0].type} != {arguments[1].type}.")
+                function_type = Callable[[arguments[0].type, arguments[1].type], bool]
         return self.new_function_application(self.new_constant(operator_, function_type), arguments)
 
     def __add__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.add)
+        return self._new_binary_arithmetic(other, operator.add)
 
     # We can also write __radd__ = __add__. But it may be better to keep the order?
     def __radd__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.add, reverse=True)
+        return self._new_binary_arithmetic(other, operator.add, reverse=True)
 
     def __mul__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.mul)
+        return self._new_binary_arithmetic(other, operator.mul)
 
     def __rmul__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.mul, reverse=True)
+        return self._new_binary_arithmetic(other, operator.mul, reverse=True)
 
     def __sub__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.sub)
+        return self._new_binary_arithmetic(other, operator.sub)
 
     def __rsub__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.sub, reverse=True)
+        return self._new_binary_arithmetic(other, operator.sub, reverse=True)
 
     def __neg__(self) -> Expression:
         return self.new_function_application(self.new_constant(operator.neg, Callable[[self.type], self.type]), [self])
@@ -252,19 +268,34 @@ class Expression(ABC):
         if isinstance(other, Expression) and other.and_priority > self.and_priority:
             return other.__and__(self)
         else:
-            return self._new_binary_operation(other, operator.and_, Callable[[bool, bool], bool])
+            return self._new_binary_boolean(other, operator.and_)
 
     def __rand__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.and_, Callable[[bool, bool], bool], reverse=True)
+        return self._new_binary_boolean(other, operator.and_, reverse=True)
 
     def __or__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.or_, Callable[[bool, bool], bool])
+        return self._new_binary_boolean(other, operator.or_)
 
     def __ror__(self, other: Any) -> Expression:
-        return self._new_binary_operation(other, operator.or_, Callable[[bool, bool], bool], reverse=True)
+        return self._new_binary_boolean(other, operator.or_, reverse=True)
 
     def __invert__(self) -> Expression:
         return self.new_function_application(self.new_constant(operator.invert, Callable[[bool], bool]), [self])
+
+    def __lt__(self, other) -> Expression:
+        return self._new_binary_comparison(other, operator.lt)
+
+    def __le__(self, other) -> Expression:
+        return self._new_binary_comparison(other, operator.le)
+
+    def __gt__(self, other) -> Expression:
+        return self._new_binary_comparison(other, operator.gt)
+
+    def __ge__(self, other) -> Expression:
+        return self._new_binary_comparison(other, operator.ge)
+
+    # def __ne__(self, other) -> Expression:
+    #     return self._new_binary_comparison(other, operator.ne)
 
 
 class AtomicExpression(Expression, ABC):

--- a/neuralpp/symbolic/functions.py
+++ b/neuralpp/symbolic/functions.py
@@ -1,6 +1,6 @@
 """ A library that contains operators that python does not have natively. """
 
 
-def cond(if_, then_, else_):
+def conditional(if_, then_, else_):
     """ a conditional operator """
     return then_ if if_ else else_

--- a/neuralpp/symbolic/functions.py
+++ b/neuralpp/symbolic/functions.py
@@ -1,0 +1,6 @@
+""" A library that contains operators that python does not have natively. """
+
+
+def cond(if_, then_, else_):
+    """ a conditional operator """
+    return then_ if if_ else else_

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from typing import List, Any, Type, Callable, Tuple, Optional, Dict
-from abc import ABC
+from abc import ABC, abstractmethod
 
 import sympy
 from sympy import abc
@@ -15,6 +15,7 @@ from neuralpp.symbolic.expression import Expression, FunctionApplication, Variab
     FunctionNotTypedError, NotTypedError, return_type_after_application, ExpressionType, Context
 from neuralpp.symbolic.basic_expression import infer_python_callable_type
 from neuralpp.util.util import update_consistent_dict
+import neuralpp.symbolic.functions as functions
 
 
 # In this file's doc, I try to avoid the term `sympy expression` because it could mean both sympy.Expr (or sympy.Basic)
@@ -66,6 +67,7 @@ def _infer_sympy_function_type(sympy_object: sympy.Basic, type_dict: Dict[sympy.
 
 sympy_Sub = sympy.Lambda((abc.x, abc.y), abc.x - abc.y)
 sympy_Neg = sympy.Lambda((abc.x,), -abc.x)  # "lambda x: (-1)*x"
+sympy_Cond = sympy.Lambda((abc.i, abc.t, abc.e), sympy.Piecewise((abc.t, abc.i), (abc.e, True)))
 # Refer to sympy_simplification_test:test_unevaluate() for this design that uses sympy.Lambda()
 python_callable_and_sympy_function_relation = [
     # boolean operation
@@ -88,6 +90,8 @@ python_callable_and_sympy_function_relation = [
     # min/max
     (builtins.min, sympy.Min),
     (builtins.max, sympy.Max),
+    # cond
+    (functions.cond, sympy_Cond),
 ]
 sympy_function_python_callable_dict = \
     {sympy_function: python_callable
@@ -262,7 +266,38 @@ class SymPyConstant(SymPyExpression, Constant):
         return SymPyExpression.pythonize_value(self._sympy_object)
 
 
-class SymPyFunctionApplication(SymPyExpression, FunctionApplication):
+class SymPyFunctionApplicationInterface(SymPyExpression, FunctionApplication, ABC):
+    @property
+    @abstractmethod
+    def native_arguments(self) -> Tuple[sympy.Basic, ...]:
+        pass
+
+    @property
+    @abstractmethod
+    def function_type(self) -> ExpressionType:
+        pass
+
+    @property
+    def function(self) -> Expression:
+        return SymPyConstant(self._sympy_object.func, self.function_type)
+
+    @property
+    def arguments(self) -> List[Expression]:
+        return [SymPyExpression.from_sympy_object(argument, self.type_dict)
+                for argument in self.native_arguments]
+
+    @property
+    def subexpressions(self) -> List[Expression]:
+        return [self.function] + self.arguments
+
+
+class SymPyFunctionApplication(SymPyFunctionApplicationInterface):
+    def __new__(cls, sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, ExpressionType]):
+        if sympy_object.func == sympy.Piecewise:
+            return SymPyCondFunctionApplication(sympy_object, type_dict)
+        else:
+            return super().__new__(cls)
+
     def __init__(self, sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, ExpressionType]):
         """
         Calling by function_type=None asks this function to try to infer the function type.
@@ -278,26 +313,17 @@ class SymPyFunctionApplication(SymPyExpression, FunctionApplication):
         SymPyExpression.__init__(self, sympy_object, return_type, type_dict)
 
     @property
+    def function_type(self) -> ExpressionType:
+        return self._function_type
+
+    @property
     def number_of_arguments(self) -> int:
         return len(self.native_arguments)
-
-    @property
-    def function(self) -> Expression:
-        return SymPyConstant(self._sympy_object.func, self._function_type)
-
-    @property
-    def arguments(self) -> List[Expression]:
-        return [SymPyExpression.from_sympy_object(argument, self.type_dict)
-                for argument in self.native_arguments]
 
     @property
     def native_arguments(self) -> Tuple[sympy.Basic, ...]:
         """ faster than arguments """
         return self._sympy_object.args  # sympy f.args returns a tuple
-
-    @property
-    def subexpressions(self) -> List[Expression]:
-        return [self.function] + self.arguments
 
     @staticmethod
     def from_sympy_function_and_general_arguments(sympy_function: sympy.Basic, arguments: List[Expression]) -> \
@@ -310,11 +336,63 @@ class SymPyFunctionApplication(SymPyExpression, FunctionApplication):
             # see test/sympy_test.py: test_sympy_bug()
             sympy_object = sympy_function(*[sympy_argument.sympy_object for sympy_argument in sympy_arguments],
                                           evaluate=False)
-            return SymPyFunctionApplication(sympy_object, type_dict)
+        elif sympy_function == sympy.Piecewise:
+            sympy_object = sympy_piecewise_from_if_then_else(
+                *[sympy_argument.sympy_object for sympy_argument in sympy_arguments])
         else:
             with sympy.evaluate(False):
                 sympy_object = sympy_function(*[sympy_argument.sympy_object for sympy_argument in sympy_arguments])
-                return SymPyFunctionApplication(sympy_object, type_dict)
+        return SymPyFunctionApplication(sympy_object, type_dict)
+
+
+def sympy_piecewise_from_if_then_else(if_: sympy.Basic, then_: sympy.Basic, else_: sympy.Basic) -> sympy.Piecewise:
+    """ In Piecewise, cond comes after clause. """
+    return sympy.Piecewise((then_, if_), (else_, True))
+
+
+def sympy_piecewise_to_if_then_else(piecewise: sympy.Piecewise) -> Tuple[sympy.Basic, sympy.Basic, sympy.Basic]:
+    return piecewise.args[0][1], piecewise.args[0][0], piecewise.args[1][0]
+
+
+def fold_sympy_piecewise(piecewise_args: List[Tuple[sympy.Basic, sympy.Basic]]) -> sympy.Piecewise:
+    """ `fold` any sympy piecewise to 2-entry piecewise. E.g.,
+    Piecewise((s0, c0), (s1, c1), (s2, True)) will be folded into
+    Piecewise((s0, c0), (Piecewise((s1, c1), (s2, True)), True)
+    Note the last condition must be True, otherwise it cannot be transformed into if-then-else
+    """
+    if len(piecewise_args) < 2:
+        raise TypeError("piecewise is expected to have at least two entries")
+    elif len(piecewise_args) == 2:
+        if not piecewise_args[1][1]:
+            raise TypeError("No else clause: missing default value.")
+        return sympy.Piecewise(*piecewise_args)
+    else:
+        return sympy.Piecewise(piecewise_args[0], (fold_sympy_piecewise(piecewise_args[1:]), True))
+
+
+class SymPyCondFunctionApplication(SymPyFunctionApplicationInterface):
+    def __init__(self, sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, ExpressionType]):
+        if sympy_object.func != sympy.Piecewise:
+            raise TypeError("Can only create cond function application when function is sympy.Piecewise.")
+        sympy_object = fold_sympy_piecewise(sympy_object.args)
+        self._then_type = sympy_object.args[0][0]
+        SymPyExpression.__init__(self, sympy_object, self._then_type, type_dict)
+
+    @property
+    def function_type(self) -> ExpressionType:
+        return Callable[[bool, self._then_type, self._then_type], self._then_type]
+
+    @property
+    def function(self) -> Expression:
+        return SymPyConstant(self._sympy_object.func, self.function_type)
+
+    @property
+    def number_of_arguments(self) -> int:
+        return 3
+
+    @property
+    def native_arguments(self) -> Tuple[sympy.Basic, ...]:
+        return sympy_piecewise_to_if_then_else(self.sympy_object)
 
 
 def _context_to_variable_value_dict_helper(context: FunctionApplication,

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -224,7 +224,7 @@ class SymPyExpression(Expression, ABC):
     def type_dict(self) -> Dict[sympy.Basic, ExpressionType]:
         return self._type_dict
 
-    def __eq__(self, other) -> bool:
+    def syntactic_eq(self, other) -> bool:
         match other:
             case SymPyExpression(sympy_object=other_sympy_object, type_dict=other_type_dict):
                 return self.sympy_object == other_sympy_object and self.type_dict == other_type_dict

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -112,7 +112,7 @@ def _python_callable_to_z3_function(python_callable: Callable, type_: Optional[E
             raise NotImplementedError("Cannot convert min to a z3 function declaration."
                                       "However we can create z3.If(x>y, x, y) for max(x,y).")
         # if then else
-        case functions.cond:
+        case functions.conditional:
             return z3.If(x > y, x, y).decl()  # "x>y" is just a placeholder boolean.
         case _:
             raise ValueError(f"Python callable {python_callable} is not recognized.")
@@ -153,7 +153,7 @@ def _z3_function_to_python_callable(z3_function: z3.FuncDeclRef) -> Callable:
             return operator.pow
         # if then else
         case z3.Z3_OP_ITE:
-            return functions.cond
+            return functions.conditional
         case _:
             raise ValueError(f"Z3 function {z3_function} is not recognized.")
 

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -321,7 +321,7 @@ class Z3ObjectExpression(Z3Expression, ABC):
     def z3_object(self):
         return self._z3_object
 
-    def __eq__(self, other) -> bool:
+    def syntactic_eq(self, other) -> bool:
         match other:
             case Z3ObjectExpression(z3_object=other_z3_object):
                 return self.z3_object.eq(other_z3_object)
@@ -410,7 +410,7 @@ class Z3SolverExpression(Context, Z3Expression, FunctionApplication):
     def dict(self) -> Dict[str, Any]:
         return self._dict
 
-    def __eq__(self, other) -> bool:
+    def syntactic_eq(self, other) -> bool:
         return False  # why do we need to compare two Z3ConjunctiveClause?
 
     def __init__(self, z3_solver: z3.Solver, value_dict: Dict[str, Any] | None = None):

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -12,6 +12,7 @@ from neuralpp.symbolic.expression import Expression, FunctionApplication, Variab
 from neuralpp.symbolic.basic_expression import FalseContext
 from neuralpp.util.z3_util import z3_merge_solvers, z3_add_solver_and_literal
 from functools import cached_property
+import neuralpp.symbolic.functions as functions
 
 
 def _get_type_from_z3_object(z3_object: z3.ExprRef | z3.FuncDeclRef) -> ExpressionType:
@@ -110,6 +111,9 @@ def _python_callable_to_z3_function(python_callable: Callable, type_: Optional[E
             # return z3.If(arguments[0] > arguments[1], arguments[0], arguments[1])
             raise NotImplementedError("Cannot convert min to a z3 function declaration."
                                       "However we can create z3.If(x>y, x, y) for max(x,y).")
+        # if then else
+        case functions.cond:
+            return z3.If(x > y, x, y).decl()  # "x>y" is just a placeholder boolean.
         case _:
             raise ValueError(f"Python callable {python_callable} is not recognized.")
 
@@ -147,6 +151,9 @@ def _z3_function_to_python_callable(z3_function: z3.FuncDeclRef) -> Callable:
             return operator.mul
         case z3.Z3_OP_POWER:
             return operator.pow
+        # if then else
+        case z3.Z3_OP_ITE:
+            return functions.cond
         case _:
             raise ValueError(f"Z3 function {z3_function} is not recognized.")
 

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -233,7 +233,8 @@ def test_operator_overloading(expression_factory):
 
 
 def test_constants_operators():
-    from neuralpp.symbolic.constants import int_add, real_le, int_if_then_else
+    from neuralpp.symbolic.constants import int_add, real_le, int_if_then_else_function, if_then_else
+    from neuralpp.symbolic.functions import conditional
     fa0 = int_add(1, 3)
     assert fa0.arguments[0].value == 1
     assert fa0.arguments[1].value == 3
@@ -246,10 +247,20 @@ def test_constants_operators():
     assert fa2.arguments[0].function.value == operator.add
     assert fa2.arguments[1].value == 101
 
-    i = int_if_then_else(fa1, fa0, fa2)
+    i = int_if_then_else_function(fa1, fa0, fa2)
     assert i.arguments[0].function.value == operator.le
     assert i.arguments[1].function.value == operator.add
     assert i.arguments[2].function.value == operator.add
+
+    x = BasicVariable('x', int)
+    cond_expr = if_then_else(x == 1, 0.2, 0.3)
+    assert cond_expr.arguments[0].function.value == operator.eq
+    assert cond_expr.arguments[1].value == 0.2
+    assert cond_expr.arguments[2].value == 0.3
+    assert cond_expr.function.value == conditional
+
+    with pytest.raises(TypeError):
+        if_then_else(x == 1, 2, 0.3)
 
 
 def test_sympy_function_application():

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -198,7 +198,8 @@ def test_function_application(expression_factory):
     with pytest.raises(IndexError):
         fa2.set(3, constant_one)
 
-    # operator overloading
+
+def test_operator_overloading(expression_factory):
     x = expression_factory.new_variable("x", int)
     x_plus_one = x + 1
     assert x_plus_one.function.type == int_to_int_to_int
@@ -229,6 +230,26 @@ def test_function_application(expression_factory):
         # (Even if we don't raise at creation, we cannot get e.g. expr1.argument[1]
         with pytest.raises(TypeError):
             expr1 = b1 & True
+
+
+def test_constants_operators():
+    from neuralpp.symbolic.constants import int_add, real_le, int_if_then_else
+    fa0 = int_add(1, 3)
+    assert fa0.arguments[0].value == 1
+    assert fa0.arguments[1].value == 3
+
+    fa1 = real_le(fractions.Fraction(1, 3), 3)
+    assert fa1.arguments[0].value == fractions.Fraction(1, 3)
+    assert fa1.arguments[1].value == 3
+
+    fa2 = int_add(fa0, Z3Expression.new_constant(z3.IntVal(101)))
+    assert fa2.arguments[0].function.value == operator.add
+    assert fa2.arguments[1].value == 101
+
+    i = int_if_then_else(fa1, fa0, fa2)
+    assert i.arguments[0].function.value == operator.le
+    assert i.arguments[1].function.value == operator.add
+    assert i.arguments[2].function.value == operator.add
 
 
 def test_sympy_function_application():

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -164,7 +164,7 @@ def test_sympy_interpreter_simplify():
     x_only = si.simplify(x_plus_y_minus_y)  # simplifies x + y - y to x
     assert isinstance(x_only, SymPyVariable)
     assert x_only.type_dict == SymPyVariable(x, int).type_dict
-    assert x_only == SymPyVariable(x, int)
+    assert x_only.syntactic_eq(SymPyVariable(x, int))
     assert len(x_only.type_dict) == 1  # no other type information
     assert x_only.type_dict == {x: int}
 
@@ -181,7 +181,7 @@ def test_sympy_interpreter_simplify():
     b_y = BasicVariable("y", int)
     b_x_plus_y = BasicFunctionApplication(BasicConstant(operator.add, int_to_int_to_int), [b_x, b_y])
     b_x_plus_y_minus_y = BasicFunctionApplication(BasicConstant(operator.sub, int_to_int_to_int), [b_x_plus_y, b_y])
-    assert si.simplify(b_x_plus_y_minus_y) == SymPyVariable(x, int)
+    assert si.simplify(b_x_plus_y_minus_y).syntactic_eq(SymPyVariable(x, int))
     assert si.simplify(b_x_plus_y).sympy_object == x + y
 
     # with a context
@@ -210,7 +210,7 @@ def test_sympy_interpreter_simplify_operator_overload():
     x_only = si.simplify(x_plus_y_minus_y)  # simplifies x + y - y to x
     assert isinstance(x_only, SymPyVariable)
     assert x_only.type_dict == SymPyVariable(x, int).type_dict
-    assert x_only == SymPyVariable(x, int)
+    assert x_only.syntactic_eq(SymPyVariable(x, int))
     assert len(x_only.type_dict) == 1  # no other type information
     assert x_only.type_dict == {x: int}
 
@@ -226,7 +226,7 @@ def test_sympy_interpreter_simplify_operator_overload():
     b_y = BasicVariable("y", int)
     b_x_plus_y = b_x + b_y
     b_x_plus_y_minus_y = b_x_plus_y - b_y
-    assert si.simplify(b_x_plus_y_minus_y) == SymPyVariable(x, int)
+    assert si.simplify(b_x_plus_y_minus_y).syntactic_eq(SymPyVariable(x, int))
     assert si.simplify(b_x_plus_y).sympy_object == x + y
 
     # with a context

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -238,7 +238,7 @@ def test_sympy_interpreter_simplify_operator_overload():
     # convert from basic
     x_2_y_2_context = dict_to_sympy_context({"x": 2, "y": 2})
     x_3_y_2_context = dict_to_sympy_context({"x": 3, "y": 2})
-    f = BasicConstant(functions.cond, Callable[[bool, int, int], int])
+    f = BasicConstant(functions.conditional, Callable[[bool, int, int], int])
     fa = BasicFunctionApplication(f, [b_x <= 2, b_x * 100, b_y])
     assert si.simplify(fa).sympy_object == sympy.Piecewise((x*100, x <= 2), (y, True))
     assert si.simplify(fa, x_2_y_2_context).value == 200


### PR DESCRIPTION
1. Added conditional expression; created `funtions.py` that currently contains a `cond()` function; added support for conditional expression in sympy and z3; SymPy uses `PieceWise` which is bit different from `if-then-else` and requires special treatment.
2. Add support for overloading `<`, `>`, `<=`, `>=` and `!=` to create symbolic expression.
3. Changed `__eq__` semantics to creating symbolic expression. The old semantics is renamed to `syntactic_eq()`. 