### PR TITLE
context simplifer

### DIFF
--- a/neuralpp/symbolic/context_simplifier.py
+++ b/neuralpp/symbolic/context_simplifier.py
@@ -1,0 +1,97 @@
+from typing import Optional, Callable, Set
+from .expression import Expression, Context
+from .simplifier import Simplifier
+from .sympy_interpreter import SymPyInterpreter
+from .constants import basic_true, basic_false
+from .z3_expression import Z3SolverExpression
+from .parameters import sympy_evaluate
+
+
+def _implies(context: Context, expression: Expression) -> bool:
+    """
+    context implies expression iff (context => expression) is valid;
+    which means not (context => expression) is unsatisfiable;
+    which means not (not context or expression) is unsatisfiable;
+    which means context and not expression is unsatisfiable.
+    """
+    new_context = context & ~expression
+    if new_context.satisfiability_is_known:
+        return new_context.unsatisfiable
+    else:
+        return False
+
+
+def _simplify_expression(boolean_expression: Expression, context: Z3SolverExpression) -> Optional[Expression]:
+    if boolean_expression.type != bool:
+        raise TypeError("Can only simplify booleans")
+    if _implies(context, boolean_expression):
+        return basic_true
+    if _implies(context, ~boolean_expression):
+        return basic_false
+    return None
+
+
+def _collect_subset_expressions_helper(expression: Expression, test: Callable[[Expression], bool],
+                                       result: Set[Expression]):
+    if test(expression):
+        result.add(expression)
+    for sub_expression in expression.subexpressions:
+        _collect_subset_expressions_helper(sub_expression, test, result)
+
+
+def _collect_subset_expressions(expression: Expression,
+                                test: Callable[[Expression], bool] = lambda _: True, ) -> Set[Expression]:
+    """
+    Collect all subexpressions including the ones that are not immediate subexpressions and self, with a filter
+    `test`.
+    """
+    result = set()
+    _collect_subset_expressions_helper(expression, test, result)
+    return result
+
+
+class ContextSimplifier(Simplifier):
+    sympy_interpreter = SymPyInterpreter()
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def _simplify_pass(expression: Expression, context: Z3SolverExpression) -> Expression:
+        result = ContextSimplifier.sympy_interpreter.simplify(expression, context)
+        assert result is not None
+
+        # replace boolean expressions
+        all_boolean_subexpressions = _collect_subset_expressions(result, lambda expr: expr.type == bool)
+        if result is None:
+            raise
+        for boolean_subexpression in all_boolean_subexpressions:
+            simplified_subexpression = _simplify_expression(boolean_subexpression, context)
+            if simplified_subexpression is not None:
+                result = result.replace(boolean_subexpression, simplified_subexpression)
+                if result is None:
+                    raise
+
+        # replace variables
+        for variable, replacement in context.variable_replacement_dict.items():
+            result = result.replace(variable, replacement)
+        return result
+
+    def simplify(self, expression: Expression, context: Z3SolverExpression) -> Expression:
+        with sympy_evaluate(True):
+            if not isinstance(context, Z3SolverExpression):
+                raise ValueError("ContextSimplifier expects a Z3SolverExpression context.")
+            if not context.satisfiability_is_known:
+                raise Context.UnknownError()
+            if context.unsatisfiable:
+                raise ValueError(f"Context {context} is unsatisfiable.")
+
+            new_expression = ContextSimplifier._simplify_pass(expression, context)
+            # debug_i = 0
+            while not new_expression.syntactic_eq(expression):
+                expression = new_expression
+                new_expression = ContextSimplifier._simplify_pass(expression, context)
+                # debug_i += 1
+                # if debug_i > 100:
+                #     raise ValueError()
+            return new_expression

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -406,6 +406,9 @@ class FunctionApplication(Expression, ABC):
                              f"but you are setting {i-1}th arguments.")
 
     def replace(self, from_expression: Expression, to_expression: Expression) -> Expression:
+        if from_expression.syntactic_eq(self):
+            return to_expression
+
         # recursively do the replacement
         new_subexpressions = [
             to_expression if e.syntactic_eq(from_expression) else e.replace(from_expression, to_expression)

--- a/neuralpp/symbolic/parameters.py
+++ b/neuralpp/symbolic/parameters.py
@@ -1,0 +1,46 @@
+"""Thread-safe global parameters. This file mimics sympy.core.parameters. """
+
+from contextlib import contextmanager
+from threading import local
+
+
+class _GlobalParameters(local):
+    """
+    Thread-local global parameters.
+
+    Explanation
+    ===========
+
+    This class generates thread-local container for SymPy's global parameters.
+    Every global parameters must be passed as keyword argument when generating
+    its instance.
+    A variable, `global_parameters` is provided as default instance for this class.
+
+    References
+    ==========
+
+    .. [1] https://docs.python.org/3/library/threading.html
+    .. [2] sympy.core.parameters._global_parameters
+
+    """
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __setattr__(self, name, value):
+        return super().__setattr__(name, value)
+
+
+global_parameters = _GlobalParameters(sympy_evaluate=False)
+
+
+@contextmanager
+def sympy_evaluate(x):
+    old = global_parameters.sympy_evaluate
+    try:
+        global_parameters.sympy_evaluate = x
+        yield
+    except Exception as e:
+        print(f"raise: {e}")
+        raise
+    finally:
+        global_parameters.sympy_evaluate = old

--- a/neuralpp/symbolic/sympy_interpreter.py
+++ b/neuralpp/symbolic/sympy_interpreter.py
@@ -7,6 +7,7 @@ from neuralpp.symbolic.simplifier import Simplifier
 from neuralpp.symbolic.interpreter import Interpreter
 from neuralpp.symbolic.sympy_expression import SymPyExpression, _is_sympy_value, _infer_sympy_object_type
 from neuralpp.symbolic.expression import ExpressionType
+from neuralpp.symbolic.parameters import sympy_evaluate
 from typing import Dict, Any
 
 
@@ -47,12 +48,14 @@ class SymPyInterpreter(Interpreter, Simplifier):
         """
         The function calls simplify() from sympy library and wrap the result in SymPyExpression.
         """
-        if not isinstance(expression, SymPyExpression):
-            expression = SymPyExpression.convert(expression)
+        with sympy_evaluate(True):
+            if not isinstance(expression, SymPyExpression):
+                expression = SymPyExpression.convert(expression)
 
-        simplified_sympy_expression = SymPyInterpreter._simplify_expression(expression.sympy_object, context)
-        # The result keeps the known type information from `expression`. E.g., though (y-y).simplify() = 0, it still
-        # keeps the type of `y`. Delete these redundant types.
-        type_dict = SymPyInterpreter.purge_type_dict(expression.type_dict, simplified_sympy_expression)
-        result_expression = SymPyExpression.from_sympy_object(simplified_sympy_expression, type_dict)
-        return result_expression
+            simplified_sympy_expression = SymPyInterpreter._simplify_expression(expression.sympy_object, context)
+            # The result keeps the known type information from `expression`. E.g., though (y-y).simplify() = 0, it still
+            # keeps the type of `y`. Delete these redundant types.
+            type_dict = SymPyInterpreter.purge_type_dict(expression.type_dict, simplified_sympy_expression)
+            result_expression = SymPyExpression.from_sympy_object(simplified_sympy_expression, type_dict)
+            assert result_expression is not None
+            return result_expression

--- a/neuralpp/test/quick_tests/symbolic/context_simplifier_test.py
+++ b/neuralpp/test/quick_tests/symbolic/context_simplifier_test.py
@@ -1,0 +1,49 @@
+import pytest
+import sympy
+import z3
+import operator
+from neuralpp.symbolic.context_simplifier import ContextSimplifier
+from neuralpp.symbolic.sympy_expression import SymPyVariable, sympy_Cond
+from neuralpp.symbolic.z3_expression import Z3Variable, Z3SolverExpression
+from neuralpp.symbolic.constants import if_then_else
+
+
+def test_context_simplifier1():
+    si = ContextSimplifier()
+    sympy_x = SymPyVariable(sympy.symbols('x'), int)
+    x = Z3Variable(z3.Int('x'))
+    y = Z3Variable(z3.Int('y'))
+    context = Z3SolverExpression()
+    context = context & (x == y)  # parenthesis is necessary
+    context = context & (y > 4)
+    result = si.simplify(sympy_x > 3, context)
+    assert result.value  # which means result is simplified to "True"
+
+
+def test_context_simplifier2():
+    si = ContextSimplifier()
+    x = Z3Variable(z3.Int('x'))
+    y = Z3Variable(z3.Int('y'))
+    context = Z3SolverExpression()
+    context = context & (x == y)
+    context = context & (y > 4)
+    expr = if_then_else(y < if_then_else(x < 3, 1, 2), x * y, x + y)
+    result = si.simplify(expr, context)
+    assert result.function.value == operator.add
+    assert result.arguments[0].name == 'x'
+    assert result.arguments[1].name == 'y'
+
+
+def test_sympy_bug():
+    x, y = sympy.symbols('x y')
+    with pytest.raises(Exception):  # non-deterministically TypeError/RecursiveError
+        with sympy.evaluate(False):
+            sympy_Cond(y < sympy.Piecewise((1, x < 3), (2, True)), x*y, x+y)
+    with pytest.raises(Exception):  # non-deterministically TypeError/RecursiveError
+        with sympy.evaluate(False):
+            sympy.Piecewise((x*y, y < sympy.Piecewise((1, x < 3), (2, True))), (x+y, True))
+
+    with sympy.evaluate(True):
+        sympy_Cond(y < sympy.Piecewise((1, x < 3), (2, True)), x*y, x+y)
+        sympy.Piecewise((x * y, y < sympy.Piecewise((1, x < 3), (2, True))), (x + y, True))
+

--- a/neuralpp/test/quick_tests/symbolic/context_test.py
+++ b/neuralpp/test/quick_tests/symbolic/context_test.py
@@ -2,7 +2,7 @@ import pytest
 import z3
 import sympy
 
-from neuralpp.symbolic.z3_expression import Z3SolverExpression, _extract_key_value_from_assertions
+from neuralpp.symbolic.z3_expression import Z3SolverExpression, _extract_key_to_value_from_assertions
 from .interpreter_test import dict_to_sympy_context
 from z3 import Solver, Ints
 
@@ -16,7 +16,7 @@ def test_context():
     assert not z3.is_var(y)  # z3.is_var means vars in quantifier
     assert not z3.is_var((y == 2).arg(0))
     assert z3.is_int_value((y == 2).arg(1))
-    assert _extract_key_value_from_assertions([y == 2]) == {'y': 2}
+    assert _extract_key_to_value_from_assertions([y == 2]) == {'y': 2}
     context1 = Z3SolverExpression(s1)
     with pytest.raises(KeyError):
         context1.dict[y]

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -141,6 +141,7 @@ def test_sympy_interpreter():
 
     max_of_one_three = SymPyExpression.new_function_application(BasicConstant(builtins.max, int_to_int_to_int),
                                                                 [one, three])
+    assert max_of_one_three is not None
     assert si.eval(max_of_one_three) == 3
 
     min_of_three_five = SymPyExpression.new_function_application(BasicConstant(builtins.min, int_to_int_to_int),


### PR DESCRIPTION
- Define a `ContextSimplifier` subclass of `Simplifier` where the `simplify` method does the following:
  * Apply `SymPyInterpreter.simplify()` to the whole expression (to eliminate as much of the expression as possible)
  * Suppose there is a total order O on variables and constants where constants come before variables. Determine equivalence classes of variables and constants that are equaled by the context. Replace each variable by the minimum of its equivalent class according to O.
  * For every atom Gamma in the expression, replace Gamma by True if Gamma is implied by the context and by False if its negation is implied by the context.
  * Apply `SymPyInterpreter.simplify()` again to the whole expression to take those substitutions into account.