### PR TITLE
normalization

### DIFF
--- a/neuralpp/symbolic/normalizer.py
+++ b/neuralpp/symbolic/normalizer.py
@@ -1,0 +1,68 @@
+from typing import Optional, Deque
+from collections import deque
+
+from .expression import Expression, Constant, FunctionApplication
+from .z3_expression import Z3SolverExpression
+from .constants import basic_true, basic_false, if_then_else
+from .context_simplifier import ContextSimplifier
+from .parameters import sympy_evaluate
+import neuralpp.symbolic.functions as functions
+
+
+def is_boolean_atom(expression: Expression) -> bool:
+    return expression.type == bool and not isinstance(expression, Constant)  # should ignore `True` and `False`
+
+
+def _bfs_first_atom_of_expression(expression: Expression, queue: Deque) -> Optional[Expression]:
+    queue.append(expression)
+    while queue:
+        current_expression = queue.popleft()
+        if is_boolean_atom(current_expression):
+            return current_expression
+        match current_expression:
+            case FunctionApplication(function=Constant(value=functions.conditional), arguments=arguments):
+                queue.extend(arguments[1:])  # do not include the if clause, it's meaningless
+            case FunctionApplication(arguments=arguments):
+                queue.extend(arguments)
+            case _:
+                pass  # atomic expression has no subexpressions
+    return None
+
+
+def first_atom_of_expression(expression: Expression) -> Optional[Expression]:
+    """ returns the first atom occurring in a given expression in a breadth-first search. """
+    return _bfs_first_atom_of_expression(expression, deque())
+
+
+class Normalizer:
+    simplifier = ContextSimplifier()
+
+    @staticmethod
+    def _normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
+        simplified_expression = Normalizer.simplifier.simplify(expression, context)
+        first_atom = first_atom_of_expression(simplified_expression)
+        if first_atom is None:
+            return simplified_expression
+
+        print(f"first_atom {first_atom}")
+        context1 = context & first_atom
+        # The following statement can be proved by contradiction:
+        # if not isinstance(context1, Z3SolverExpression), then context & first_atom must be False,
+        # then context -> ~first_atom, then in Normalizer.simplifier.simplify(expression, context),
+        # first_atom as a subexpression of expression should have been replaced by False since its negation
+        # is implied by context, thus should not be a subexpression of simplified_expression. Q.E.D.
+        assert isinstance(context1, Z3SolverExpression)
+        expression1 = simplified_expression.replace(first_atom, basic_true)
+        then_clause = Normalizer._normalize(expression1, context1)
+
+        context2 = context & ~first_atom
+        assert isinstance(context2, Z3SolverExpression)
+        expression2 = simplified_expression.replace(first_atom, basic_false)
+        else_clause = Normalizer._normalize(expression2, context2)
+
+        return if_then_else(first_atom, then_clause, else_clause)
+
+    @staticmethod
+    def normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
+        with sympy_evaluate(True):
+            return Normalizer._normalize(expression, context)

--- a/neuralpp/test/quick_tests/symbolic/normalizer_test.py
+++ b/neuralpp/test/quick_tests/symbolic/normalizer_test.py
@@ -1,0 +1,63 @@
+import z3
+
+from neuralpp.symbolic.normalizer import Normalizer
+from neuralpp.symbolic.basic_expression import BasicVariable
+from neuralpp.symbolic.constants import if_then_else
+from neuralpp.symbolic.z3_expression import Z3SolverExpression, Z3Variable
+
+
+def test_normalizer1():
+    """
+    if a > b then a + b else 3
+    """
+    normalizer = Normalizer()
+    a = BasicVariable('a', int)
+    b = BasicVariable('b', int)
+    expr = if_then_else(a > b, a + b, 3)
+    context = Z3SolverExpression()
+    result1 = normalizer.normalize(expr, context)
+    assert result1.structure_eq(expr)
+
+    context = context & (a == b)
+    result2 = normalizer.normalize(expr, context)
+    assert result2.value == 3
+
+
+def test_normalizer2():
+    """
+    f: bool -> bool -> int -> int
+    f(a > b, b > c, 5)
+    """
+    normalizer = Normalizer()
+    f = Z3Variable(z3.Function('f', z3.BoolSort(), z3.BoolSort(), z3.IntSort(), z3.IntSort()))
+    a = BasicVariable('a', int)
+    b = BasicVariable('b', int)
+    c = BasicVariable('c', int)
+
+    expr = f(a < b, b > c, 5)
+    context = Z3SolverExpression()
+    context = context & (f(True, True, 5) == 42) & (f(True, False, 5) == 99)
+    assert isinstance(context, Z3SolverExpression)
+    result = normalizer.normalize(expr, context)
+    assert result.structure_eq(if_then_else(a < b,
+                                            if_then_else(b > c, 42, 99),
+                                            if_then_else(b > c, f(False, True, 5), f(False, False, 5))))
+
+
+def test_normalizer3():
+    """
+    f: bool -> int -> int
+    f(c, f((a > b) | c, 3))
+    """
+    normalizer = Normalizer()
+    f = Z3Variable(z3.Function('f', z3.BoolSort(), z3.IntSort(), z3.IntSort()))
+    a = BasicVariable('a', int)
+    b = BasicVariable('b', int)
+    c = BasicVariable('c', bool)
+
+    expr = f(c, f((a > b) | c, 3))
+    context = Z3SolverExpression()
+    context = context & (f(True, 66) == 45) & (f(True, 3) == 66) & (f(False, 3) == 3)
+    assert isinstance(context, Z3SolverExpression)
+    result = normalizer.normalize(expr, context)
+    assert result.structure_eq(if_then_else(c, 45, if_then_else(a > b, f(False, 66), 3)))


### PR DESCRIPTION
- Wrote a utility method that returns the first formula occurring in a given expression in a breadth-first search.
- Defined a class Normalizer with a method `normalize(e: Expression, context: Z3SolverExpression) -> Expression` that does the following:
  - Simplify the expression `e`.
  - Search for the first atom in the expression `e`.
  - If there is no atom in the expression `e`, return `e`. Otherwise:
  - Compute `context1` obtained by conjoining the atom with `context`.
  - Compute `context2` obtained by conjoining the negation of the atom with `context`.
  - Obtain `e1` by replacing atom by `True` in `e`.
  - Obtain `e2` by replacing atom by `False` in `e`.
  - Obtain `n1` by normalizing `e1` with context `c1`.
  - Obtain `n2` by normalizing `e2` with context `c2`.
  - Return expression `if atom then n1 else n2`.