### PR TITLE
quantifier expressions

### DIFF
--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import operator
 import builtins
 from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, AtomicExpression, \
-    VariableNotTypedError, ExpressionType, get_arithmetic_function_type_from_argument_types, Context
+    VariableNotTypedError, ExpressionType, get_arithmetic_function_type_from_argument_types, Context, \
+    QuantifierExpression
 from abc import ABC
-from typing import Any, List, Optional, Callable, Dict
+from typing import Any, List, Optional, Callable, Dict, get_args
 import neuralpp.symbolic.functions as functions
 
 
@@ -72,6 +73,11 @@ class BasicExpression(Expression, ABC):
     @classmethod
     def new_function_application(cls, function: Expression, arguments: List[Expression]) -> BasicFunctionApplication:
         return BasicFunctionApplication(function, arguments)
+
+    @classmethod
+    def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
+                                  ) -> QuantifierExpression:
+        return BasicQuantifierExpression(operation, index, constrain, body)
 
 
 class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):
@@ -167,8 +173,52 @@ class BasicFunctionApplication(BasicExpression, FunctionApplication):
 
     def syntactic_eq(self, other) -> bool:
         match other:
-            case BasicFunctionApplication(function=function, arguments=arguments, type=other_type):
-                return all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, [function] + arguments)) and \
-                       self.type == other_type
+            case BasicFunctionApplication(subexpressions=other_subexpressions):
+                return all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
             case _:
                 return False
+
+
+class BasicQuantifierExpression(QuantifierExpression, BasicExpression):
+    def __init__(self, operation: Constant, index: Variable, constrain: Expression, body: Expression):
+        self._operation = operation
+        self._index = index
+        self._constrain = constrain
+        self._body = body
+        argument_types, return_type = get_args(operation.type)
+        if len(argument_types) != 2 or not (argument_types[0] == argument_types [1] == return_type):
+            raise ValueError(f"Wrong operation type {operation.type}.")
+        super().__init__(return_type)
+
+    @property
+    def operation(self) -> Constant:
+        return self._operation
+
+    @property
+    def index(self) -> Variable:
+        return self._index
+
+    @property
+    def constrain(self) -> Expression:
+        return self._constrain
+
+    @property
+    def body(self) -> Expression:
+        return self._body
+
+    def syntactic_eq(self, other) -> bool:
+        match other:
+            case BasicQuantifierExpression(subexpressions=other_subexpressions):
+                return all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
+            case _:
+                return False
+
+
+class BasicSummation(BasicQuantifierExpression):
+    def __init__(self, type_: type, index: Variable, constrain: Expression, body: Expression):
+        """
+        Expect type_ to be the argument type/return type of the summation.
+        E.g., the type_ of Summation{i in [0,100]}(i) should be `int`.
+        """
+        summation_operation = BasicConstant(operator.add, Callable[[type_, type_], type_])
+        super().__init__(summation_operation, index, constrain, body)

--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -174,7 +174,8 @@ class BasicFunctionApplication(BasicExpression, FunctionApplication):
     def syntactic_eq(self, other) -> bool:
         match other:
             case BasicFunctionApplication(subexpressions=other_subexpressions):
-                return all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
+                return len(self.subexpressions) == len(other_subexpressions) and \
+                       all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
             case _:
                 return False
 

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -141,7 +141,8 @@ class Expression(ABC):
                   FunctionApplication(subexpressions=other_subexpressions)) | \
                  (QuantifierExpression(subexpressions=self_subexpressions),
                   QuantifierExpression(subexpressions=other_subexpressions)):
-                return all(lhs.structure_eq(rhs) for lhs, rhs in zip(self_subexpressions, other_subexpressions))
+                return len(self_subexpressions) == len(other_subexpressions) and \
+                       all(lhs.structure_eq(rhs) for lhs, rhs in zip(self_subexpressions, other_subexpressions))
             case _:
                 return False
 

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -443,10 +443,7 @@ class FunctionApplication(Expression, ABC):
             return to_expression
 
         # recursively do the replacement
-        new_subexpressions = [
-            to_expression if e.syntactic_eq(from_expression) else e.replace(from_expression, to_expression)
-            for e in self.subexpressions
-        ]
+        new_subexpressions = [e.replace(from_expression, to_expression) for e in self.subexpressions]
         return self.new_function_application(new_subexpressions[0], new_subexpressions[1:])
 
     def __str__(self) -> str:
@@ -517,10 +514,7 @@ class QuantifierExpression(Expression, ABC):
             return to_expression
 
         # recursively do the replacement
-        new_subexpressions = [
-            to_expression if e.syntactic_eq(from_expression) else e.replace(from_expression, to_expression)
-            for e in self.subexpressions
-        ]
+        new_subexpressions = [e.replace(from_expression, to_expression) for e in self.subexpressions]
         return self.new_quantifier_expression(*new_subexpressions)
 
 

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -12,7 +12,7 @@ import fractions
 
 from functools import cached_property
 from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, \
-    FunctionNotTypedError, NotTypedError, return_type_after_application, ExpressionType, Context
+    FunctionNotTypedError, NotTypedError, return_type_after_application, ExpressionType, Context, QuantifierExpression
 from neuralpp.symbolic.basic_expression import infer_python_callable_type
 from neuralpp.util.util import update_consistent_dict
 from neuralpp.symbolic.parameters import global_parameters
@@ -205,6 +205,11 @@ class SymPyExpression(Expression, ABC):
                 raise ValueError("The function must be a python callable.")
             case _:
                 raise ValueError("Unknown case.")
+
+    @classmethod
+    def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
+                                  ) -> QuantifierExpression:
+        raise NotImplementedError()
 
     @classmethod
     def pythonize_value(cls, value: sympy.Basic) -> Any:

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -8,7 +8,8 @@ from abc import ABC, abstractmethod
 import z3
 import operator
 import builtins
-from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, ExpressionType, Context
+from neuralpp.symbolic.expression import Expression, FunctionApplication, Variable, Constant, ExpressionType, Context, \
+    QuantifierExpression
 from neuralpp.symbolic.basic_expression import FalseContext
 from neuralpp.util.z3_util import z3_merge_solvers, z3_add_solver_and_literal, is_z3_uninterpreted_function
 from functools import cached_property, total_ordering
@@ -281,6 +282,11 @@ class Z3Expression(Expression, ABC):
                 raise ValueError("The function must be a python callable.")
             case _:
                 raise ValueError(f"Unknown case: {function}")
+
+    @classmethod
+    def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
+                                  ) -> QuantifierExpression:
+        raise NotImplementedError()
 
     @classmethod
     def pythonize_value(cls, value: z3.ExprRef | z3.FuncDeclRef) -> Any:

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -10,7 +10,7 @@ import math
 from typing import Callable, Any
 from neuralpp.symbolic.sympy_interpreter import SymPyInterpreter
 from neuralpp.symbolic.basic_expression import BasicFunctionApplication, BasicConstant, BasicVariable, \
-    BasicExpression
+    BasicExpression, BasicQuantifierExpression, BasicSummation
 from neuralpp.symbolic.sympy_expression import SymPyConstant, SymPyExpression, _python_callable_to_sympy_function, \
     _sympy_function_to_python_callable, SymPyFunctionApplication, SymPyVariable, _infer_sympy_function_type, \
     _infer_sympy_object_type
@@ -135,6 +135,21 @@ def test_basic_function_application():
     fa7 = fa4.replace(constant_one, constant_two)
     assert fa7.syntactic_eq(BasicFunctionApplication(
         func3, [constant_two, BasicFunctionApplication(func2, [constant_two, constant_two])]))
+
+
+def test_basic_quantifier_expressions():
+    i = BasicVariable('i', int)
+    i_range = (0 < i) & (i < 10)
+    sum_ = BasicSummation(int, i, i_range, i)
+    assert sum_.subexpressions[0].syntactic_eq(BasicConstant(operator.add, Callable[[int, int], int]))
+    assert sum_.subexpressions[1].syntactic_eq(i)
+    assert sum_.subexpressions[2].syntactic_eq(i_range)
+    assert sum_.subexpressions[3].syntactic_eq(i)
+    assert len(sum_.subexpressions) == 4
+    a = BasicVariable('a', int)
+    new_sum = sum_.replace(i, a)
+    assert sum_.syntactic_eq(BasicSummation(int, i, (0 < i) & (i < 10), i))
+    assert new_sum.syntactic_eq(BasicSummation(int, a, (0 < a) & (a < 10), a))
 
 
 @pytest.fixture(params=[operator.and_, operator.or_, operator.invert, operator.xor, operator.le,

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -138,18 +138,27 @@ def test_basic_function_application():
 
 
 def test_basic_quantifier_expressions():
+    from neuralpp.symbolic.constants import int_add, int_multiply
     i = BasicVariable('i', int)
     i_range = (0 < i) & (i < 10)
     sum_ = BasicSummation(int, i, i_range, i)
-    assert sum_.subexpressions[0].syntactic_eq(BasicConstant(operator.add, Callable[[int, int], int]))
+    assert sum_.subexpressions[0].syntactic_eq(int_add)
     assert sum_.subexpressions[1].syntactic_eq(i)
     assert sum_.subexpressions[2].syntactic_eq(i_range)
     assert sum_.subexpressions[3].syntactic_eq(i)
     assert len(sum_.subexpressions) == 4
+
     a = BasicVariable('a', int)
     new_sum = sum_.replace(i, a)
     assert sum_.syntactic_eq(BasicSummation(int, i, (0 < i) & (i < 10), i))
     assert new_sum.syntactic_eq(BasicSummation(int, a, (0 < a) & (a < 10), a))
+
+    assert sum_.set(0, int_multiply).syntactic_eq(BasicQuantifierExpression(int_multiply, i, (0 < i) & (i < 10), i))
+
+    sum_ia = new_sum.set(3, i * a)
+    nested_sum = sum_.set(3, sum_ia)
+    assert nested_sum.syntactic_eq(BasicSummation(int, i, (0 < i) & (i < 10),
+                                                  BasicSummation(int, a, (0 < a) & (a < 10), i * a)))
 
 
 @pytest.fixture(params=[operator.and_, operator.or_, operator.invert, operator.xor, operator.le,

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -389,3 +389,12 @@ def test_type_inference():
     sympy_expr: sympy.Basic = (a > b) | (a <= -b)
     assert _infer_sympy_function_type(sympy_expr, {a: int, b: int}) == Callable[[bool, bool], bool]
     assert _infer_sympy_object_type(sympy_expr, {a: int, b: int}) == bool
+
+
+def test_function_application_eq():
+    from neuralpp.symbolic.constants import int_add
+    a = BasicVariable('a', int)
+    fa = a + 1
+    fa2 = BasicFunctionApplication(int_add, [a])
+    assert not fa.syntactic_eq(fa2)
+    assert not fa.structure_eq(fa2)


### PR DESCRIPTION
- Define a new interface QuantifiedExpression subclassing Expression. It should provide:
  - a property `operation` providing the function on which the quantifier is based (for example, or for existential quantification, and for universal quantification, + for summation, * for product).
  - a property `index` for the variable over which this quantifier iterates.
  - a property `constraint` for the formula expression determining the values of the index over which the quantier iterates.
  - a property `body` for the expression being quantified.
  - Example: `sum_{x : x != 3 and x > 1} x^1 + 2`
- Define an implementation of `BasicQuantifier`.
- Define a class `Summation` subclassing BasicQuantifier for operator `+`.
- Write unit tests.
