### PR TITLE
normalization of quantifier expression

### DIFF
--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -99,7 +99,7 @@ class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):
     def atom(self) -> str:
         return self._atom
 
-    def syntactic_eq(self, other) -> bool:
+    def internal_object_eq(self, other) -> bool:
         match other:
             case BasicAtomicExpression(base_type=other_base_type, atom=other_atom, type=other_type):
                 return other_base_type == self.base_type and self.type == other_type and self.atom == other_atom
@@ -175,11 +175,11 @@ class BasicFunctionApplication(BasicExpression, FunctionApplication):
     def number_of_arguments(self) -> int:
         return len(self.arguments)
 
-    def syntactic_eq(self, other) -> bool:
+    def internal_object_eq(self, other) -> bool:
         match other:
             case BasicFunctionApplication(subexpressions=other_subexpressions):
                 return len(self.subexpressions) == len(other_subexpressions) and \
-                       all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
+                       all(lhs.internal_object_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
             case _:
                 return False
 
@@ -211,10 +211,10 @@ class BasicQuantifierExpression(QuantifierExpression, BasicExpression):
     def body(self) -> Expression:
         return self._body
 
-    def syntactic_eq(self, other) -> bool:
+    def internal_object_eq(self, other) -> bool:
         match other:
             case BasicQuantifierExpression(subexpressions=other_subexpressions):
-                return all(lhs.syntactic_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
+                return all(lhs.internal_object_eq(rhs) for lhs, rhs in zip(self.subexpressions, other_subexpressions))
             case _:
                 return False
 

--- a/neuralpp/symbolic/context_simplifier.py
+++ b/neuralpp/symbolic/context_simplifier.py
@@ -71,9 +71,7 @@ class ContextSimplifier(Simplifier):
 
         # replace variables
         for variable, replacement in context.variable_replacement_dict.items():
-            # `variable` and `replacement` are Z3Expressions, replace() checks syntactic_eq,
-            # so we need to convert them to SymPyExpressions since result is a SymPyExpression.
-            result = result.replace(SymPyExpression.convert(variable), SymPyExpression.convert(replacement))
+            result = result.replace(variable, replacement)
         return result
 
     def simplify(self, expression: Expression, context: Z3SolverExpression) -> Expression:

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -189,7 +189,7 @@ class Expression(ABC):
 
     @classmethod
     @abstractmethod
-    def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
+    def new_quantifier_expression(cls, operation: Constant, index: Variable, constraint: Expression, body: Expression,
                                   ) -> Expression:
         pass
 
@@ -532,7 +532,7 @@ class QuantifierExpression(Expression, ABC):
 
     @property
     @abstractmethod
-    def constrain(self) -> Context:
+    def constraint(self) -> Context:
         """ User can expect the returning `expression` to be a Boolean Expression, i.e., expression.type == bool. """
         pass
 
@@ -543,7 +543,7 @@ class QuantifierExpression(Expression, ABC):
 
     @property
     def subexpressions(self) -> List[Expression]:
-        return [self.operation, self.index, self.constrain, self.body]
+        return [self.operation, self.index, self.constraint, self.body]
 
     def set(self, i: int, new_expression: Expression) -> QuantifierExpression:
         subexpressions = self.subexpressions
@@ -568,14 +568,14 @@ class QuantifierExpression(Expression, ABC):
     def set_index(self, new_expression: Expression) -> QuantifierExpression:
         return self.set(1, new_expression)
 
-    def set_constrain(self, new_expression: Expression) -> QuantifierExpression:
+    def set_constraint(self, new_expression: Expression) -> QuantifierExpression:
         return self.set(2, new_expression)
 
     def set_body(self, new_expression: Expression) -> QuantifierExpression:
         return self.set(3, new_expression)
 
     def __str__(self) -> str:
-        return f'"{self.operation}({self.index}:{self.constrain}, {self.body})"'
+        return f'"{self.operation}({self.index}:{self.constraint}, {self.body})"'
 
 
 class NotTypedError(ValueError, TypeError):

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -190,7 +190,7 @@ class Expression(ABC):
     @classmethod
     @abstractmethod
     def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
-                                  ) -> QuantifierExpression:
+                                  ) -> Expression:
         pass
 
     @classmethod

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -497,7 +497,8 @@ class Context(Expression, ABC):
 
 class AbelianOperation(Constant, ABC):
     """
-    An Abelian operation is a commutative, associative binary operation with an identity element.
+    An Abelian operation is a commutative, associative binary operation with an identity element:
+    https://en.wikipedia.org/wiki/Abelian_group
     """
     @property
     @abstractmethod
@@ -518,8 +519,10 @@ class QuantifierExpression(Expression, ABC):
     @property
     @abstractmethod
     def operation(self) -> AbelianOperation:
-        """ operation is a Constant wrapping a function.
-        E.g., integer Summation's operation is Constant(operator.add, Callable[[int,int],int]). """
+        """
+        operation is a Constant wrapping a function.
+        E.g., integer Summation's operation is Constant(operator.add, Callable[[int,int],int]).
+        """
         pass
 
     @property

--- a/neuralpp/symbolic/normalizer.py
+++ b/neuralpp/symbolic/normalizer.py
@@ -86,7 +86,7 @@ class Normalizer:
     @staticmethod
     def _quantifier_expression_normalize(expression: QuantifierExpression, context: Z3SolverExpression) -> Expression:
         """ The function assumes context is satisfiable, otherwise will raise. """
-        if context.structurally_contains(expression.index):
+        if context.contains(expression.index):
             raise ValueError(f"{context} should not contain {expression.index}, which is not a free variable!")
 
         normalized_body = Normalizer._normalize(expression.body, context)
@@ -94,7 +94,7 @@ class Normalizer:
             case FunctionApplication(function=function, arguments=arguments,
                                      ) if function.value == functions.conditional:
                 condition, then_clause, else_clause = arguments  # if len(arguments) != 3, raise
-                if condition.structurally_contains(expression.index):
+                if condition.contains(expression.index):
                     new_then_clause = BasicExpression.new_quantifier_expression(
                         expression.operation, expression.index, expression.constraint & condition, then_clause)
                     new_else_clause = BasicExpression.new_quantifier_expression(

--- a/neuralpp/symbolic/normalizer.py
+++ b/neuralpp/symbolic/normalizer.py
@@ -1,7 +1,8 @@
 from typing import Optional, Deque
 from collections import deque
 
-from .expression import Expression, Constant, FunctionApplication
+from .expression import Expression, Constant, FunctionApplication, QuantifierExpression
+from .basic_expression import BasicQuantifierExpression, BasicFunctionApplication, BasicExpression
 from .z3_expression import Z3SolverExpression
 from .constants import basic_true, basic_false, if_then_else
 from .context_simplifier import ContextSimplifier
@@ -38,7 +39,12 @@ class Normalizer:
     simplifier = ContextSimplifier()
 
     @staticmethod
-    def _normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
+    def _basic_normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
+        """
+        The word `basic` in the function name is not to be confused with that in `BasicExpression`.
+        Here it refers to normalization of non-quantifier expressions.
+        The function assumes context is satisfiable, otherwise will raise (from Normalizer.simplifier.simplify()).
+        """
         simplified_expression = Normalizer.simplifier.simplify(expression, context)
         # We look for non-constant formula, because we should not split on constants (i.e., True/False)
         # as it is meaningless and would cause the algorithm to not terminate.
@@ -65,6 +71,37 @@ class Normalizer:
         return if_then_else(first_non_constant_formula, then_clause, else_clause)
 
     @staticmethod
+    def _normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
+        """ The function assumes context is satisfiable, otherwise will raise. """
+        if isinstance(expression, QuantifierExpression):
+            if context.structurally_contains(expression.index):
+                raise ValueError(f"{context} should not contain {expression.index}, which is not a free variable!")
+            return Normalizer._quantifier_expression_normalize(expression, context)
+        else:
+            return Normalizer._basic_normalize(expression, context)
+
+    @staticmethod
     def normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
         with sympy_evaluate(True):
             return Normalizer._normalize(expression, context)
+
+    @staticmethod
+    def _quantifier_expression_normalize(expression: QuantifierExpression, context: Z3SolverExpression) -> Expression:
+        """ The function assumes context is satisfiable, otherwise will raise. """
+        normalized_body = Normalizer._normalize(expression.body, context)
+        match normalized_body:
+            case FunctionApplication(function=function, arguments=arguments,
+                                     ) if function.value == functions.conditional:
+                condition, then_clause, else_clause = arguments  # if len(arguments) != 3, raise
+                if condition.structurally_contains(expression.index):
+                    new_then_clause = BasicExpression.new_quantifier_expression(
+                        expression.operation, expression.index, expression.constrain & condition, then_clause)
+                    new_else_clause = BasicExpression.new_quantifier_expression(
+                        expression.operation, expression.index, expression.constrain & ~condition, else_clause)
+                    return BasicFunctionApplication(expression.operation, [new_then_clause, new_else_clause])
+                else:
+                    return BasicFunctionApplication(function, [condition,
+                                                               expression.set_body(then_clause),
+                                                               expression.set_body(else_clause)])
+            case _:
+                return expression.set_body(normalized_body)

--- a/neuralpp/symbolic/normalizer.py
+++ b/neuralpp/symbolic/normalizer.py
@@ -96,9 +96,9 @@ class Normalizer:
                 condition, then_clause, else_clause = arguments  # if len(arguments) != 3, raise
                 if condition.structurally_contains(expression.index):
                     new_then_clause = BasicExpression.new_quantifier_expression(
-                        expression.operation, expression.index, expression.constrain & condition, then_clause)
+                        expression.operation, expression.index, expression.constraint & condition, then_clause)
                     new_else_clause = BasicExpression.new_quantifier_expression(
-                        expression.operation, expression.index, expression.constrain & ~condition, else_clause)
+                        expression.operation, expression.index, expression.constraint & ~condition, else_clause)
                     return BasicFunctionApplication(expression.operation, [new_then_clause, new_else_clause])
                 else:
                     return BasicFunctionApplication(function, [condition,

--- a/neuralpp/symbolic/normalizer.py
+++ b/neuralpp/symbolic/normalizer.py
@@ -74,8 +74,6 @@ class Normalizer:
     def _normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
         """ The function assumes context is satisfiable, otherwise will raise. """
         if isinstance(expression, QuantifierExpression):
-            if context.structurally_contains(expression.index):
-                raise ValueError(f"{context} should not contain {expression.index}, which is not a free variable!")
             return Normalizer._quantifier_expression_normalize(expression, context)
         else:
             return Normalizer._basic_normalize(expression, context)
@@ -88,6 +86,9 @@ class Normalizer:
     @staticmethod
     def _quantifier_expression_normalize(expression: QuantifierExpression, context: Z3SolverExpression) -> Expression:
         """ The function assumes context is satisfiable, otherwise will raise. """
+        if context.structurally_contains(expression.index):
+            raise ValueError(f"{context} should not contain {expression.index}, which is not a free variable!")
+
         normalized_body = Normalizer._normalize(expression.body, context)
         match normalized_body:
             case FunctionApplication(function=function, arguments=arguments,

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -237,7 +237,7 @@ class SymPyExpression(Expression, ABC):
     def type_dict(self) -> Dict[sympy.Basic, ExpressionType]:
         return self._type_dict
 
-    def syntactic_eq(self, other) -> bool:
+    def internal_object_eq(self, other) -> bool:
         match other:
             case SymPyExpression(sympy_object=other_sympy_object, type_dict=other_type_dict):
                 return self.sympy_object == other_sympy_object and self.type_dict == other_type_dict

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -207,7 +207,7 @@ class SymPyExpression(Expression, ABC):
                 raise ValueError("Unknown case.")
 
     @classmethod
-    def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
+    def new_quantifier_expression(cls, operation: Constant, index: Variable, constraint: Expression, body: Expression,
                                   ) -> Expression:
         raise NotImplementedError()
 

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -208,7 +208,7 @@ class SymPyExpression(Expression, ABC):
 
     @classmethod
     def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
-                                  ) -> QuantifierExpression:
+                                  ) -> Expression:
         raise NotImplementedError()
 
     @classmethod

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -184,7 +184,7 @@ class SymPyExpression(Expression, ABC):
         return SymPyVariable(sympy_var, type_)
 
     @classmethod
-    def new_function_application(cls, function: Expression, arguments: List[Expression]) -> SymPyFunctionApplication:
+    def new_function_application(cls, function: Expression, arguments: List[Expression]) -> SymPyExpression:
         # we cannot be lazy here because the goal is to create a sympy object, so arguments must be
         # recursively converted to sympy object
         match function:

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -285,7 +285,7 @@ class Z3Expression(Expression, ABC):
                 raise ValueError(f"Unknown case: {function}")
 
     @classmethod
-    def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
+    def new_quantifier_expression(cls, operation: Constant, index: Variable, constraint: Expression, body: Expression,
                                   ) -> Expression:
         raise NotImplementedError()
 
@@ -440,7 +440,7 @@ class Z3SolverExpression(Context, Z3Expression, FunctionApplication):
 
     def replace(self, from_expression: Expression, to_expression: Expression) -> Z3SolverExpression:
         """
-        If we do not override this replace(), the default replace() will causing the return value to be
+        If we do not override this replace(), the default replace() will cause the return value to be
         a Z3FunctionApplication, where the result is no longer a Context.
         """
         from_expression = Z3Expression.convert(from_expression)

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -447,9 +447,10 @@ class Z3SolverExpression(Context, Z3Expression, FunctionApplication):
         to_expression = Z3Expression.convert(to_expression)
 
         if not isinstance(from_expression, Z3ObjectExpression):
-            raise ValueError()  # only possible when from_expression is Z3SolverExpression
+            # only possible when from_expression is Z3SolverExpression
+            raise ValueError(f"{from_expression}({type(from_expression)}) does not have a z3_object.")
         if not isinstance(to_expression, Z3ObjectExpression):
-            raise ValueError()
+            raise ValueError(f"{to_expression}({type(to_expression)}) does not have a z3_object.")
 
         new_solver = z3_replace_in_solver(self._solver, from_expression.z3_object, to_expression.z3_object)
         return Z3SolverExpression(new_solver)

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -438,7 +438,7 @@ class Z3SolverExpression(Context, Z3Expression, FunctionApplication):
     def internal_object_eq(self, other) -> bool:
         return False  # why do we need to compare two Z3ConjunctiveClause?
 
-    def replace(self, from_expression: Expression, to_expression: Expression) -> Z3SolverExpression:
+    def replace(self, from_expression: Expression, to_expression: Expression) -> Context:
         """
         If we do not override this replace(), the default replace() will cause the return value to be
         a Z3FunctionApplication, where the result is no longer a Context.

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -286,7 +286,7 @@ class Z3Expression(Expression, ABC):
 
     @classmethod
     def new_quantifier_expression(cls, operation: Constant, index: Variable, constrain: Expression, body: Expression,
-                                  ) -> QuantifierExpression:
+                                  ) -> Expression:
         raise NotImplementedError()
 
     @classmethod

--- a/neuralpp/test/quick_tests/symbolic/interpreter_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interpreter_test.py
@@ -165,7 +165,7 @@ def test_sympy_interpreter_simplify():
     x_only = si.simplify(x_plus_y_minus_y)  # simplifies x + y - y to x
     assert isinstance(x_only, SymPyVariable)
     assert x_only.type_dict == SymPyVariable(x, int).type_dict
-    assert x_only.syntactic_eq(SymPyVariable(x, int))
+    assert x_only.internal_object_eq(SymPyVariable(x, int))
     assert len(x_only.type_dict) == 1  # no other type information
     assert x_only.type_dict == {x: int}
 
@@ -182,7 +182,7 @@ def test_sympy_interpreter_simplify():
     b_y = BasicVariable("y", int)
     b_x_plus_y = BasicFunctionApplication(BasicConstant(operator.add, int_to_int_to_int), [b_x, b_y])
     b_x_plus_y_minus_y = BasicFunctionApplication(BasicConstant(operator.sub, int_to_int_to_int), [b_x_plus_y, b_y])
-    assert si.simplify(b_x_plus_y_minus_y).syntactic_eq(SymPyVariable(x, int))
+    assert si.simplify(b_x_plus_y_minus_y).internal_object_eq(SymPyVariable(x, int))
     assert si.simplify(b_x_plus_y).sympy_object == x + y
 
     # with a context
@@ -211,7 +211,7 @@ def test_sympy_interpreter_simplify_operator_overload():
     x_only = si.simplify(x_plus_y_minus_y)  # simplifies x + y - y to x
     assert isinstance(x_only, SymPyVariable)
     assert x_only.type_dict == SymPyVariable(x, int).type_dict
-    assert x_only.syntactic_eq(SymPyVariable(x, int))
+    assert x_only.internal_object_eq(SymPyVariable(x, int))
     assert len(x_only.type_dict) == 1  # no other type information
     assert x_only.type_dict == {x: int}
 
@@ -227,7 +227,7 @@ def test_sympy_interpreter_simplify_operator_overload():
     b_y = BasicVariable("y", int)
     b_x_plus_y = b_x + b_y
     b_x_plus_y_minus_y = b_x_plus_y - b_y
-    assert si.simplify(b_x_plus_y_minus_y).syntactic_eq(SymPyVariable(x, int))
+    assert si.simplify(b_x_plus_y_minus_y).internal_object_eq(SymPyVariable(x, int))
     assert si.simplify(b_x_plus_y).sympy_object == x + y
 
     # with a context

--- a/neuralpp/test/quick_tests/symbolic/normalizer_test.py
+++ b/neuralpp/test/quick_tests/symbolic/normalizer_test.py
@@ -17,7 +17,7 @@ def test_normalizer1():
     expr = if_then_else(a > b, a + b, 3)
     context = Z3SolverExpression()
     result1 = normalizer.normalize(expr, context)
-    assert result1.structure_eq(expr)
+    assert result1.syntactic_eq(expr)
 
     context = context & (a == b)
     result2 = normalizer.normalize(expr, context)
@@ -40,7 +40,7 @@ def test_normalizer2():
     context = context & (f(True, True, 5) == 42) & (f(True, False, 5) == 99)
     assert isinstance(context, Z3SolverExpression)
     result = normalizer.normalize(expr, context)
-    assert result.structure_eq(if_then_else(a < b,
+    assert result.syntactic_eq(if_then_else(a < b,
                                             if_then_else(b > c, 42, 99),
                                             if_then_else(b > c, f(False, True, 5), f(False, False, 5))))
 
@@ -78,7 +78,7 @@ def test_normalizer3():
     context = context & (f(True, 66) == 45) & (f(True, 3) == 66) & (f(False, 3) == 3)
     assert isinstance(context, Z3SolverExpression)
     result = normalizer.normalize(expr, context)
-    assert result.structure_eq(if_then_else(c, 45, if_then_else(a > b, f(False, 66), 3)))
+    assert result.syntactic_eq(if_then_else(c, 45, if_then_else(a > b, f(False, 66), 3)))
 
 
 def test_quantifier_normalizer():
@@ -90,7 +90,7 @@ def test_quantifier_normalizer():
 
     context = empty_context
     normalizer = Normalizer()
-    assert normalizer.normalize(sum_, context).structure_eq(sum_)
+    assert normalizer.normalize(sum_, context).syntactic_eq(sum_)
 
     context = empty_context & (i < 5)
     # raises ValueError because the context should not contain index (in this case i),
@@ -101,25 +101,25 @@ def test_quantifier_normalizer():
     j = BasicVariable('j', int)
     sum_ = BasicSummation(int, i, empty_context & (j < i) & (i < 10), i + j)
     context = empty_context & (j == 5)
-    assert normalizer.normalize(sum_, context).structure_eq(
+    assert normalizer.normalize(sum_, context).syntactic_eq(
         BasicSummation(int, i, empty_context & (j < i) & (i < 10), 5 + i))  # SymPy switched 5 and i
 
     context = empty_context & (j == 10)
-    assert normalizer.normalize(sum_, context).structure_eq(
+    assert normalizer.normalize(sum_, context).syntactic_eq(
         BasicSummation(int, i, empty_context & (j < i) & (i < 10), 10 + i))
     # not reduced to 0 because j < i < 10 is still satisfiable
-    assert not normalizer.normalize(sum_, context).structure_eq(BasicConstant(0, int))
+    assert not normalizer.normalize(sum_, context).syntactic_eq(BasicConstant(0, int))
 
     sum_ = BasicSummation(int, i, empty_context & (j < i), if_then_else(j > 5, i + j, i))
-    assert normalizer.normalize(sum_, empty_context).structure_eq(
+    assert normalizer.normalize(sum_, empty_context).syntactic_eq(
         if_then_else(j > 5,
                      BasicSummation(int, i, empty_context & (j < i), i + j),
                      BasicSummation(int, i, empty_context & (j < i), i)))
-    assert normalizer.normalize(sum_, empty_context & (j == 6)).structure_eq(
+    assert normalizer.normalize(sum_, empty_context & (j == 6)).syntactic_eq(
         BasicSummation(int, i, empty_context & (j < i), 6 + i))
 
     sum_ = BasicSummation(int, i, empty_context & (j < i), if_then_else(i > 5, i + j, i))
-    assert normalizer.normalize(sum_, empty_context).structure_eq(
+    assert normalizer.normalize(sum_, empty_context).syntactic_eq(
                      BasicSummation(int, i, empty_context & (j < i) & (i > 5), i + j) +
                      BasicSummation(int, i, empty_context & (j < i) & (i <= 5), i))
 

--- a/neuralpp/test/quick_tests/symbolic/normalizer_test.py
+++ b/neuralpp/test/quick_tests/symbolic/normalizer_test.py
@@ -1,7 +1,8 @@
+import pytest
 import z3
 
 from neuralpp.symbolic.normalizer import Normalizer
-from neuralpp.symbolic.basic_expression import BasicVariable
+from neuralpp.symbolic.basic_expression import BasicVariable, BasicSummation, BasicConstant
 from neuralpp.symbolic.constants import if_then_else
 from neuralpp.symbolic.z3_expression import Z3SolverExpression, Z3Variable
 
@@ -78,3 +79,50 @@ def test_normalizer3():
     assert isinstance(context, Z3SolverExpression)
     result = normalizer.normalize(expr, context)
     assert result.structure_eq(if_then_else(c, 45, if_then_else(a > b, f(False, 66), 3)))
+
+
+def test_quantifier_normalizer():
+    from neuralpp.symbolic.constants import int_add, int_multiply
+    i = BasicVariable('i', int)
+    empty_context = Z3SolverExpression()
+    i_range = empty_context & (0 < i) & (i < 10)
+    sum_ = BasicSummation(int, i, i_range, i)
+
+    context = empty_context
+    normalizer = Normalizer()
+    assert normalizer.normalize(sum_, context).structure_eq(sum_)
+
+    context = empty_context & (i < 5)
+    with pytest.raises(ValueError):
+        normalizer.normalize(sum_, context)
+
+    j = BasicVariable('j', int)
+    sum_ = BasicSummation(int, i, empty_context & (j < i) & (i < 10), i + j)
+    context = empty_context & (j == 5)
+    assert normalizer.normalize(sum_, context).structure_eq(
+        BasicSummation(int, i, empty_context & (j < i) & (i < 10), 5 + i))  # SymPy switched 5 and i
+
+    context = empty_context & (j == 10)
+    assert normalizer.normalize(sum_, context).structure_eq(
+        BasicSummation(int, i, empty_context & (j < i) & (i < 10), 10 + i))
+    # not reduced to 0 because j < i < 10 is still satisfiable
+    assert not normalizer.normalize(sum_, context).structure_eq(BasicConstant(0, int))
+
+    sum_ = BasicSummation(int, i, empty_context & (j < i), if_then_else(j > 5, i + j, i))
+    assert normalizer.normalize(sum_, empty_context).structure_eq(
+        if_then_else(j > 5,
+                     BasicSummation(int, i, empty_context & (j < i), i + j),
+                     BasicSummation(int, i, empty_context & (j < i), i)))
+    assert normalizer.normalize(sum_, empty_context & (j == 6)).structure_eq(
+        BasicSummation(int, i, empty_context & (j < i), 6 + i))
+
+    sum_ = BasicSummation(int, i, empty_context & (j < i), if_then_else(i > 5, i + j, i))
+    assert normalizer.normalize(sum_, empty_context).structure_eq(
+                     BasicSummation(int, i, empty_context & (j < i) & (i > 5), i + j) +
+                     BasicSummation(int, i, empty_context & (j < i) & (i <= 5), i))
+
+    # Normalization of nested quantifier expression is not supported, yet.
+    sum_ = BasicSummation(int, j, empty_context & (j < 10), if_then_else(j > 5, i + j, sum_))
+    # because SymPyQuantifierExpression is not implemented.
+    with pytest.raises(NotImplementedError):
+        normalizer.normalize(sum_, empty_context)

--- a/neuralpp/test/quick_tests/symbolic/normalizer_test.py
+++ b/neuralpp/test/quick_tests/symbolic/normalizer_test.py
@@ -93,6 +93,8 @@ def test_quantifier_normalizer():
     assert normalizer.normalize(sum_, context).structure_eq(sum_)
 
     context = empty_context & (i < 5)
+    # raises ValueError because the context should not contain index (in this case i),
+    # since the index of the quantifier expression is not a free variable and not visible to the context.
     with pytest.raises(ValueError):
         normalizer.normalize(sum_, context)
 

--- a/neuralpp/util/z3_util.py
+++ b/neuralpp/util/z3_util.py
@@ -1,4 +1,4 @@
-from z3 import Solver, FuncDeclRef, Z3_OP_UNINTERPRETED
+from z3 import Solver, FuncDeclRef, Z3_OP_UNINTERPRETED, ExprRef, substitute
 from typing import Any
 from copy import copy
 
@@ -14,6 +14,14 @@ def z3_add_solver_and_literal(solver: Solver, constraint: Any) -> Solver:
     """  Make a new solver from the older solver and the added constraint. This function does not modify arguments. """
     result = copy(solver)
     result.add(constraint)
+    return result
+
+
+def z3_replace_in_solver(solver: Solver, from_: ExprRef, to: ExprRef) -> Solver:
+    """  Make a new solver from the older solver by replacing `from_` to `to`. """
+    result = Solver()
+    for assertion in solver.assertions():
+        result.add(substitute(assertion, (from_, to)))
     return result
 
 


### PR DESCRIPTION
Write an algorithm that, given `Quant_{x: F} E` and context `C`, rewrites it as follows:
- `N <- normalize(E, C and F)`
- if `N` is not an if then else expression, return `Quant_{x: F} N`. Otherwise:
- `N` is of the form `if Cond then N1 else N2`
- If `Cond` contains index `x`
   - Return `(Quant_{x: F and Cond} N1) + (Quant_{x: F and not Cond} N2)`
- else
   - Return `if Cond then Quant_{x: F} N1 else Quant_{x: F} N2`