### PR TITLE
interval interface

### DIFF
--- a/neuralpp/symbolic/interval.py
+++ b/neuralpp/symbolic/interval.py
@@ -1,32 +1,65 @@
 from __future__ import annotations
-from abc import abstractmethod
-from typing import Iterable, Callable
-from constants import if_then_else
 
-from .expression import Variable, Expression, Context
+import builtins
+from typing import Iterable, List, Set
+
+from .expression import Variable, Expression, Context, Constant
+from .basic_expression import BasicExpression
 from .z3_expression import Z3SolverExpression
 
 
-class ClosedInterval:
+class ClosedInterval(BasicExpression):
     """ [lower_bound, upper_bound] """
     @property
-    @abstractmethod
+    def subexpressions(self) -> List[Expression]:
+        return [self.lower_bound, self.upper_bound]
+
+    def set(self, i: int, new_expression: Expression) -> Expression:
+        if i == 0:
+            return ClosedInterval(new_expression, self.upper_bound)
+        if i == 1:
+            return ClosedInterval(self.lower_bound, new_expression)
+        raise IndexError("out of scope.")
+
+    def replace(self, from_expression: Expression, to_expression: Expression) -> Expression:
+        if self.syntactic_eq(from_expression):
+            return to_expression
+        return ClosedInterval(self.lower_bound.replace(from_expression, to_expression),
+                              self.upper_bound.replace(from_expression, to_expression))
+
+    def internal_object_eq(self, other) -> bool:
+        if not isinstance(other, ClosedInterval):
+            return False
+        return self.lower_bound.internal_object_eq(other.lower_bound) and \
+               self.upper_bound.internal_object_eq(other.upper_bound)
+
+    def __init__(self, lower_bound, upper_bound):
+        super().__init__(Set)
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+
+    @property
     def lower_bound(self) -> Expression:
-        pass
+        return self._lower_bound
 
     @property
-    @abstractmethod
     def upper_bound(self) -> Expression:
-        pass
+        return self._upper_bound
 
-    @abstractmethod
     def to_range(self) -> Iterable[Expression]:
-        """ if upper and lower bounds are constant, return a range that's iterable """
-        pass
+        """
+        If upper and lower bounds are constant, return a range that's iterable.
+        Otherwise, raise
+        """
+        match self.lower_bound, self.upper_bound:
+            case Constant(value=l, type=builtins.int), Constant(value=r, type=builtins.int):
+                return range(l, r)
+            case _:
+                raise TypeError("Lower and upper bounds must both be Constants!")
 
     @property
-    def length(self) -> Expression:
-        return self.upper_bound - self.lower_bound
+    def size(self) -> Expression:
+        return self.upper_bound - self.lower_bound + 1
 
     def to_context(self, index: Variable) -> Context:
         result = Z3SolverExpression() & index >= self.lower_bound & index <= self.upper_bound
@@ -34,42 +67,42 @@ class ClosedInterval:
         return result
 
 
-class GeneralIntervals:
-    @staticmethod
-    def from_constraint(index: Variable, constraint: Expression) -> GeneralIntervals:
-        pass
-
-    @abstractmethod
-    def map_leaves(self, function: Callable[[DottedIntervals], Expression]) -> Expression:
-        """ Recurse over the leaves (DottedIntervals), apply @param `function` to them, and compose an Expression. """
-        pass
-
-
-class DottedIntervals(GeneralIntervals):
+class DottedIntervals(BasicExpression):
     @property
-    @abstractmethod
-    def __iter__(self) -> Iterable[ClosedInterval]:
-        pass
+    def subexpressions(self) -> List[Expression]:
+        return [self.interval] + self.dots
 
-    def map_leaves(self, function: Callable[[DottedIntervals], Expression]) -> Expression:
-        return function(self)
+    def set(self, i: int, new_expression: Expression) -> Expression:
+        raise NotImplementedError("TODO")
 
+    def replace(self, from_expression: Expression, to_expression: Expression) -> Expression:
+        raise NotImplementedError("TODO")
 
-class ConditionalIntervals(GeneralIntervals):
-    @property
-    @abstractmethod
-    def if_(self) -> Expression:
-        pass
+    def internal_object_eq(self, other) -> bool:
+        raise NotImplementedError("TODO")
+
+    def __init__(self, interval: ClosedInterval, dots: List[Expression]):
+        super().__init__(Set)
+        self._interval = interval
+        self._dots = dots
 
     @property
-    @abstractmethod
-    def then(self) -> GeneralIntervals:
-        pass
+    def dots(self) -> List[Expression]:
+        return self._dots
 
     @property
-    @abstractmethod
-    def else_(self) -> GeneralIntervals:
-        pass
+    def interval(self) -> ClosedInterval:
+        return self._interval
 
-    def map_leaves(self, function: Callable[[DottedIntervals], Expression]) -> Expression:
-        return if_then_else(self.if_, self.then.map_leaves(function), self.else_.map_leaves(function))
+    @property
+    def __iter__(self) -> Iterable[Constant]:
+        raise NotImplementedError("TODO")
+
+
+def from_constraints(index: Variable, constraint: Context) -> Expression:
+    """
+    @param index:
+    @param constraint:
+    @return: an if-then-else tree whose leaves are DottedIntervals
+    """
+    raise NotImplementedError("TODO")

--- a/neuralpp/symbolic/interval.py
+++ b/neuralpp/symbolic/interval.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from abc import abstractmethod
+from typing import Iterable, Callable
+from constants import if_then_else
+
+from .expression import Variable, Expression, Context
+from .z3_expression import Z3SolverExpression
+
+
+class ClosedInterval:
+    """ [lower_bound, upper_bound] """
+    @property
+    @abstractmethod
+    def lower_bound(self) -> Expression:
+        pass
+
+    @property
+    @abstractmethod
+    def upper_bound(self) -> Expression:
+        pass
+
+    @abstractmethod
+    def to_range(self) -> Iterable[Expression]:
+        """ if upper and lower bounds are constant, return a range that's iterable """
+        pass
+
+    @property
+    def length(self) -> Expression:
+        return self.upper_bound - self.lower_bound
+
+    def to_context(self, index: Variable) -> Context:
+        result = Z3SolverExpression() & index >= self.lower_bound & index <= self.upper_bound
+        assert isinstance(result, Context)  # otherwise lower_bound <= upper_bound is unsatisfiable
+        return result
+
+
+class GeneralIntervals:
+    @staticmethod
+    def from_constraint(index: Variable, constraint: Expression) -> GeneralIntervals:
+        pass
+
+    @abstractmethod
+    def map_leaves(self, function: Callable[[DottedIntervals], Expression]) -> Expression:
+        """ Recurse over the leaves (DottedIntervals), apply @param `function` to them, and compose an Expression. """
+        pass
+
+
+class DottedIntervals(GeneralIntervals):
+    @property
+    @abstractmethod
+    def __iter__(self) -> Iterable[ClosedInterval]:
+        pass
+
+    def map_leaves(self, function: Callable[[DottedIntervals], Expression]) -> Expression:
+        return function(self)
+
+
+class ConditionalIntervals(GeneralIntervals):
+    @property
+    @abstractmethod
+    def if_(self) -> Expression:
+        pass
+
+    @property
+    @abstractmethod
+    def then(self) -> GeneralIntervals:
+        pass
+
+    @property
+    @abstractmethod
+    def else_(self) -> GeneralIntervals:
+        pass
+
+    def map_leaves(self, function: Callable[[DottedIntervals], Expression]) -> Expression:
+        return if_then_else(self.if_, self.then.map_leaves(function), self.else_.map_leaves(function))


### PR DESCRIPTION
We (Rodrigo, Winnie, and I) had some discussions over the interval interface. We came to conclude that `Interval` should not inherit `Expression`.

The difficult part about interval is that the return type of `from_constraint(constraint)` is an if-then-else tree of intervals, which I propose an interface in this PR, using `DottedIntervals` and `ConditionalIntervals`.