### PR TITLE
add support for integration

### DIFF
--- a/neuralpp/symbolic/interval.py
+++ b/neuralpp/symbolic/interval.py
@@ -111,7 +111,8 @@ class DottedIntervals(BasicExpression):
 def from_constraint(index: Variable, constraint: Context, context: Context, is_integral: bool) -> Expression:
     """
     @param index: the variable that the interval is for
-    @param constraint: the context that constrains the variable
+    @param constraint: the constraint of the quantifier expression
+    @param context: the context that the expression is in
     @param is_integral: whether asking for an integration (if yes return as is, instead of rounding), a bit hacky
     @return: an DottedInterval
 
@@ -142,7 +143,8 @@ def _extract_bound_from_constraint(
     @param index: the variable that the interval is for
     @param constraint: the context that constrains the variable
     @param closed_interval: the current ClosedInterval
-    @exceptions: a list of exceptions
+    @param exceptions: a list of exceptions
+    @param is_integral: whether we're extracting bound for an integral (in which case don't round)
     @return: a tuple of closed_interval and list of exceptions
 
     Extracts the operator, where in the expression the variable is, and possible lower or upper bound

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -290,6 +290,7 @@ class Z3Expression(Expression, ABC):
 
     @classmethod
     def new_quantifier_expression(cls, operation: Constant, index: Variable, constraint: Expression, body: Expression,
+                                  is_integral: bool,
                                   ) -> Expression:
         raise NotImplementedError()
 

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -566,6 +566,19 @@ class Z3SolverExpression(Context, Z3Expression, FunctionApplication):
 
     __rand__ = __and__
 
+    @staticmethod
+    def from_expression(expression: Expression) -> Z3SolverExpression:
+        # a possible improvement is to split expression into subexpressions if it's an "And"
+        assert isinstance(expression, Expression)
+        if isinstance(expression, Z3SolverExpression):
+            return expression
+
+        if not isinstance(expression, Z3Expression):
+            expression = Z3Expression.convert(expression)
+        new_solver = z3.Solver()
+        new_solver.add(expression.z3_object)
+        return Z3SolverExpression(new_solver)
+
     @cached_property
     def variable_replacement_dict(self):
         """

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -156,7 +156,9 @@ def test_basic_quantifier_expressions():
     assert new_sum.syntactic_eq(BasicSummation(int, a, context & (0 < a) & (a < 10), a))
 
     assert sum_.set(0, int_multiply).syntactic_eq(BasicQuantifierExpression(int_multiply, i,
-                                                                            context & (0 < i) & (i < 10), i))
+                                                                            context & (0 < i) & (i < 10), i,
+                                                                            False
+                                                                            ))
 
     sum_ia = new_sum.set(3, i * a)
     nested_sum = sum_.set(3, sum_ia)

--- a/neuralpp/test/quick_tests/symbolic/interval_test.py
+++ b/neuralpp/test/quick_tests/symbolic/interval_test.py
@@ -10,7 +10,7 @@ def test_basic_constant_closed_intervals():
     empty_context = Z3SolverExpression()
     constant_context = empty_context & (i < 5) & (i > 0)
 
-    dotted_interval = from_constraint(i, constant_context)
+    dotted_interval = from_constraint(i, constant_context, empty_context, False)
     interval = dotted_interval.interval
 
     assert interval.lower_bound.syntactic_eq(Z3Expression.new_constant(1))
@@ -24,7 +24,7 @@ def test_basic_symbolic_closed_intervals():
     empty_context = Z3SolverExpression()
     constant_context = empty_context & (i < 5) & (i > x)
 
-    dotted_interval = from_constraint(i, constant_context)
+    dotted_interval = from_constraint(i, constant_context, empty_context, False)
     interval = dotted_interval.interval
 
     assert interval.lower_bound.syntactic_eq(1 + x)
@@ -33,7 +33,7 @@ def test_basic_symbolic_closed_intervals():
     empty_context = Z3SolverExpression()
     constant_context = empty_context & (i <= x + 5) & (i > x + 2)
 
-    dotted_interval = from_constraint(i, constant_context)
+    dotted_interval = from_constraint(i, constant_context, empty_context, False)
     interval = dotted_interval.interval
 
     assert interval.lower_bound.syntactic_eq(3 + x)

--- a/neuralpp/test/quick_tests/symbolic/normalizer_test.py
+++ b/neuralpp/test/quick_tests/symbolic/normalizer_test.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 from neuralpp.symbolic.quantifier_free_normalizer import QuantifierFreeNormalizer
 from neuralpp.symbolic.general_normalizer import GeneralNormalizer
-from neuralpp.symbolic.basic_expression import BasicVariable, BasicSummation, BasicConstant, BasicFunctionApplication
+from neuralpp.symbolic.basic_expression import BasicVariable, BasicSummation, BasicConstant, BasicIntegral
 from neuralpp.symbolic.constants import if_then_else
 from neuralpp.symbolic.z3_expression import Z3SolverExpression, Z3Variable
 from neuralpp.symbolic.sympy_expression import SymPyExpression
@@ -115,27 +115,36 @@ def test_quantifier_normalizer():
     j = BasicVariable('j', int)
     sum_ = BasicSummation(int, i, empty_context & (j < i) & (i < 10), i + j)
     context = empty_context & (j == 5)
-    assert normalizer.normalize(sum_, context).syntactic_eq(
-        BasicSummation(int, i, empty_context & (j < i) & (i < 10), 5 + i))  # SymPy switched 5 and i
+    # 6 + 7 + 8 + 9 + 5 * 4 = 50
+    assert normalizer.normalize(sum_, context).syntactic_eq(BasicConstant(50))  # SymPy switched 5 and i
 
     context = empty_context & (j == 10)
     assert normalizer.normalize(sum_, context).syntactic_eq(BasicConstant(0, int))
 
-    sum_ = BasicSummation(int, i, empty_context & (j < i), if_then_else(j > 5, i + j, i))
+    k = BasicVariable('k', int)
+    jj, kk = sympy.symbols('j k')
+    sum_ = BasicSummation(int, i, empty_context & (j < i) & (i < k), if_then_else(j > 5, i + j, i))
     assert normalizer.normalize(sum_, empty_context).syntactic_eq(
         if_then_else(j > 5,
-                     BasicSummation(int, i, empty_context & (j < i), i + j),
-                     BasicSummation(int, i, empty_context & (j < i), i)))
+                     SymPyExpression.from_sympy_object(
+                         - jj ** 2 / 2 - jj * (jj - kk + 1) - jj / 2 + kk ** 2 / 2 - kk / 2,
+                         {jj: int, kk: int}),
+                     SymPyExpression.from_sympy_object(- jj ** 2 / 2 - jj / 2 + kk ** 2 / 2 - kk / 2,
+                                                       {jj: int, kk: int}),
+                     ))
     assert normalizer.normalize(sum_, empty_context & (j == 6)).syntactic_eq(
-        BasicSummation(int, i, empty_context & (j < i), 6 + i))
+        SymPyExpression.from_sympy_object(
+            kk ** 2 / 2 + 11 * kk / 2 - 63,
+            {kk: int})
+    )
 
     sum_ = BasicSummation(int, i, empty_context & (j < i), if_then_else(i > 5, i + j, i))
     assert normalizer.normalize(sum_, empty_context).syntactic_eq(
         BasicSummation(int, i, empty_context & (j < i) & (5 < i), i + j) +
         BasicSummation(int, i, empty_context & (j < i) & ~(5 < i), i))
 
-    assert(normalizer.normalize(BasicSummation(int, j, empty_context & (10 > j) & (j > 5), i + j),
-                                empty_context)).syntactic_eq(30 + 4 * i)
+    assert (normalizer.normalize(BasicSummation(int, j, empty_context & (10 > j) & (j > 5), i + j),
+                                 empty_context)).syntactic_eq(30 + 4 * i)
     # Normalization of nested quantifier expression
     sum_ = BasicSummation(int, j, empty_context & (j < 10), if_then_else(j > 5, i + j, sum_))
     assert normalizer.normalize(sum_, empty_context).syntactic_eq(
@@ -176,22 +185,17 @@ def test_quantifier_normalizer():
                                                                     BasicSummation(int, C,
                                                                                    empty_context & (0 < C) & (C < 10),
                                                                                    if_then_else(B < 5, C, 1)))))
+    BB, CC = sympy.symbols('B C')
+    product = SymPyExpression.from_sympy_object(9 * BB * (BB + CC), {BB: int, CC: int})
     assert normalizer.normalize(expr, empty_context).syntactic_eq(
         if_then_else(A,
                      if_then_else(B > 4,
-                                  f(B, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), B * (B + C))),
-                                  f(B, BasicSummation(int, D, empty_context & (0 < D) & (D < 10),
-                                                      B * (
-                                                          BasicSummation(int, C, empty_context & (0 < C) & (C < 10), C))
-                                                      ))),
+                                  f(B, product),
+                                  f(B, 405 * B)),
                      if_then_else(B > 4,
-                                  f(C, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), B * (B + C))),
-                                  f(C, BasicSummation(int, D, empty_context & (0 < D) & (D < 10),
-                                                      B * (
-                                                          BasicSummation(int, C, empty_context & (0 < C) & (C < 10), C))
-                                                      )))))
-    assert normalizer.normalize(expr, empty_context & A & (B > 4)).syntactic_eq(
-        f(B, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), B * (B + C))))
+                                  f(C, product),
+                                  f(C, 405 * B))))
+    assert normalizer.normalize(expr, empty_context & A & (B > 4)).syntactic_eq(f(B, product))
 
     # if we have "B==4" in the context of a subtree, B will be substituted by 4
     #          f
@@ -214,11 +218,65 @@ def test_quantifier_normalizer():
 
     expr = f(if_then_else(A, B, C), BasicSummation(int, D, empty_context & (0 < D) & (D < 10),
                                                    B * if_then_else(B == 4, B + C, 1)))
+    product2 = SymPyExpression.from_sympy_object(144 + 36 * CC, {CC: int})
     assert normalizer.normalize(expr, empty_context).syntactic_eq(
         if_then_else(A,
-                     if_then_else(B == 4,
-                                  f(4, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), 16 + 4 * C)),
-                                  f(B, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), B))),
-                     if_then_else(B == 4,
-                                  f(C, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), 16 + 4 * C)),
-                                  f(C, BasicSummation(int, D, empty_context & (0 < D) & (D < 10), B)))))
+                     if_then_else(B == 4, f(4, product2), f(B, 9 * B)),
+                     if_then_else(B == 4, f(C, product2), f(C, 9 * B))))
+
+
+def test_quantifier_normalizer_integration():
+    i = BasicVariable('i', int)
+    empty_context = Z3SolverExpression()
+    i_range = empty_context & (0 < i) & (i < 10)
+    integral = BasicIntegral(i, i_range, i)
+
+    context = empty_context
+    normalizer = GeneralNormalizer()
+    # 1/2 * i ** 2
+    assert normalizer.normalize(integral, context).syntactic_eq(BasicConstant(50))
+    # 1/2 * i ** 2 + i
+    assert normalizer.normalize(BasicIntegral(i, i_range, i + 1), context).syntactic_eq(BasicConstant(60))
+
+    #          *
+    #       /    \
+    #     if A   Integral
+    #     /  \    |
+    #    B    C  B * if B>4
+    #                /    \
+    #               B+C   Integral
+    #                       |
+    #                      if B<5
+    #                      / \
+    #                     C   1
+    # should be normalized to
+    #              if A
+    #           /        \
+    #      if B>4       if B>4
+    #       /    \        /   \
+    #      *      ..   ..      * (= C * 10 * 50 = 500 * B * C)
+    #     /\                  /  \
+    #    B  Integral(D)      C   Integral(D)    (= *10)
+    #        |                    |
+    #       B*(B+C)             B*Integral(C)  (= B * 1/2 * C ** 2 {C:[0,10]} = 50 * B)
+    f = BasicVariable('f', Callable[[int, int], int])
+    A = BasicVariable('A', bool)
+    B = BasicVariable('B', int)
+    C = BasicVariable('C', int)
+    D = BasicVariable('D', int)
+    expr = if_then_else(A, B, C) * BasicIntegral(D, empty_context & (0 < D) & (D < 10),
+                                                 B * if_then_else(B > 4,
+                                                                  B + C,
+                                                                  BasicIntegral(C,
+                                                                                empty_context & (0 < C) & (C < 10),
+                                                                                if_then_else(B < 5, C, 1))))
+    BB, CC = sympy.symbols('B C')
+    product = SymPyExpression.from_sympy_object(10 * BB ** 2 * (BB + CC), {BB: int, CC: int})
+    product2 = SymPyExpression.from_sympy_object(10 * BB * CC * (BB + CC), {BB: int, CC: int})
+    product3 = SymPyExpression.from_sympy_object(500 * BB * CC, {BB: int, CC: int})
+    assert normalizer.normalize(expr, empty_context).syntactic_eq(
+        if_then_else(A,
+                     if_then_else(B > 4, product, 500 * B ** 2),
+                     if_then_else(B > 4, product2, product3),
+                     ))
+    assert normalizer.normalize(expr, empty_context & A & (B > 4)).syntactic_eq(product)

--- a/neuralpp/test/quick_tests/symbolic/normalizer_test.py
+++ b/neuralpp/test/quick_tests/symbolic/normalizer_test.py
@@ -240,11 +240,11 @@ def test_quantifier_normalizer_integration():
 
     #          *
     #       /    \
-    #     if A   Integral
+    #     if A   Integral D\in(0,10)
     #     /  \    |
     #    B    C  B * if B>4
     #                /    \
-    #               B+C   Integral
+    #               B+C   Integral C\in(0,10)
     #                       |
     #                      if B<5
     #                      / \
@@ -254,11 +254,13 @@ def test_quantifier_normalizer_integration():
     #           /        \
     #      if B>4       if B>4
     #       /    \        /   \
-    #      *      ..   ..      * (= C * 10 * 50 = 500 * B * C)
+    #      *      ..   ..      * (= C * {right below} = 500 * B * C)
     #     /\                  /  \
-    #    B  Integral(D)      C   Integral(D)    (= *10)
+    #    B  Integral(D)      C   Integral(D,(0,10))    (= {body below} * 10 = 50 * B * 10 = 500 * B)
     #        |                    |
-    #       B*(B+C)             B*Integral(C)  (= B * 1/2 * C ** 2 {C:[0,10]} = 50 * B)
+    #       B*(B+C)             B*Integral(C,(0,10))  (= B * Integral(C\in(0,10),C) = B * 1/2 * C ** 2 {C:[0,10]} = 50 * B)
+    #                                  |
+    #                                  C
     f = BasicVariable('f', Callable[[int, int], int])
     A = BasicVariable('A', bool)
     B = BasicVariable('B', int)


### PR DESCRIPTION
The motivation of this PR is to support integration/integrals. Integral is a very similar "quantifier operation" to sum, in the way that they behave exactly the same in normalization algorithm except the final "elimination" (in elimination, integrals integrate, while sums sum). In this PR, I added a property `is_integral` to `QuantifierExpression`, to represent Integral. I am not exactly sure that this is the most elegant design, but this is a rather short path to the goal given our current code base.