### PR TITLE
Refactoring of Symbolic

### DIFF
--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -3,8 +3,10 @@ from __future__ import annotations  # to support forward reference for recursive
 import fractions
 import typing
 import operator
+import z3
 from typing import List, Any, Optional, Type, Callable, Dict
 from abc import ABC, abstractmethod
+
 
 # typing.Callable can be ambiguous.
 # Consider the following two tests:
@@ -38,7 +40,6 @@ from abc import ABC, abstractmethod
 #
 # It should be noted that our usage of `Callable` here means the first, i.e., "the type of all function types"
 # And in our code we use `isinstance()` for cases like `isinstance(Callable[[int],int], Callable)`.
-import z3
 
 ExpressionType = Callable | Type
 
@@ -53,7 +54,6 @@ def return_type_after_application(callable_: Callable, number_of_arguments: int)
         return return_type
     else:
         return Callable[argument_types[number_of_arguments:], return_type]
-
 
 type_order_in_arithmetic = [fractions.Fraction, float, int]
 
@@ -120,8 +120,8 @@ class Expression(ABC):
         """
         Returns if self and other are of subclass of Expression and their internal representation are equal.
         This method usually depends on subclass-specific library calls,
-        e.g., Z3Expression.syntactic_eq() would leverage z3.eq().
-        This method should be considered as a cheap way to check syntactic equality of two symbolic expressions.
+        e.g., Z3Expression.internal_object_eq() would leverage z3.eq().
+        This method should be considered as a cheap way to check internal object equality of two symbolic expressions.
         """
         pass
 
@@ -402,19 +402,6 @@ class AtomicExpression(Expression, ABC):
         raise IndexError(f"{type(self)} has no subexpressions, so you cannot set().")
 
 
-class Variable(AtomicExpression, ABC):
-    @property
-    def base_type(self) -> str:
-        return "Variable"
-
-    @property
-    def name(self) -> str:
-        return self.atom
-
-    def __str__(self) -> str:
-        return f'{self.name}'
-
-
 class Constant(AtomicExpression, ABC):
     @property
     def base_type(self) -> str:
@@ -426,6 +413,19 @@ class Constant(AtomicExpression, ABC):
 
     def __str__(self) -> str:
         return f"{self.value}"
+
+
+class Variable(AtomicExpression, ABC):
+    @property
+    def base_type(self) -> str:
+        return "Variable"
+
+    @property
+    def name(self) -> str:
+        return self.atom
+
+    def __str__(self) -> str:
+        return f'{self.name}'
 
 
 class FunctionApplication(Expression, ABC):

--- a/neuralpp/symbolic/general_normalizer.py
+++ b/neuralpp/symbolic/general_normalizer.py
@@ -15,23 +15,6 @@ _simplifier = ContextSimplifier()
 _eliminator = Eliminator()
 
 
-def _normalize_conditional(condition: Expression, then: Expression, else_: Expression, context: Z3SolverExpression):
-    """
-    Arguments condition-then-else_ forms an if-then-else statement.
-    If either branch can be pruned (its negation implied by context), it is pruned.
-    It is not just an optimization but a requirement that every prunable be pruned:
-    otherwise we'd call normalize() with an unsatisfiable context, which is not well-defined.
-    """
-    if context.is_known_to_imply(condition):
-        return _normalize(then, context)
-    elif context.is_known_to_imply(~condition):
-        return _normalize(else_, context)
-    else:
-        return if_then_else(condition,
-                            _normalize(then, context & condition),
-                            _normalize(else_, context & ~condition))
-
-
 def _normalize(expression: Expression, context: Z3SolverExpression) -> Expression:
     """
     The function assumes context is satisfiable, otherwise the behavior is undefined.
@@ -81,6 +64,23 @@ def _normalize(expression: Expression, context: Z3SolverExpression) -> Expressio
                                                       context)
                 case _:
                     return _eliminate(operation, index, constraint, normalized_body, is_integral, context)
+
+
+def _normalize_conditional(condition: Expression, then: Expression, else_: Expression, context: Z3SolverExpression):
+    """
+    Arguments condition-then-else_ forms an if-then-else statement.
+    If either branch can be pruned (its negation implied by context), it is pruned.
+    It is not just an optimization but a requirement that every prunable be pruned:
+    otherwise we'd call normalize() with an unsatisfiable context, which is not well-defined.
+    """
+    if context.is_known_to_imply(condition):
+        return _normalize(then, context)
+    elif context.is_known_to_imply(~condition):
+        return _normalize(else_, context)
+    else:
+        return if_then_else(condition,
+                            _normalize(then, context & condition),
+                            _normalize(else_, context & ~condition))
 
 
 def _eliminate(operation: AbelianOperation, index: Variable, constraint: Context, body: Expression,

--- a/neuralpp/symbolic/interpreter.py
+++ b/neuralpp/symbolic/interpreter.py
@@ -6,7 +6,7 @@ class Interpreter(ABC):
     @abstractmethod
     def eval(self, expression: Expression, context: Context):
         """
-        Evaluations the `expression` under the constraint of `context` being true.
+        Evaluation of the `expression` under the constraint of `context` being true.
         Either returns a value s.t., context -> expression == value
         or raise AttributeError when it's too difficult for the Interpreter; or
         raise Error encountered when applying function.

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -198,6 +198,14 @@ class SymPyExpression(Expression, ABC):
             return None
 
     @classmethod
+    def new_variable(cls, name: str, type_: ExpressionType) -> SymPyVariable:
+        # if a string contains a whitespace it'll be treated as multiple variables in sympy.symbols
+        if ' ' in name:
+            raise ValueError(f"`{name}` should not contain a whitespace!")
+        sympy_var = sympy.symbols(name)
+        return SymPyVariable(sympy_var, type_)
+
+    @classmethod
     def new_constant(cls, value: Any, type_: Optional[ExpressionType] = None) -> SymPyConstant:
         # if a string contains a whitespace it'll be treated as multiple variables in sympy.symbols
         if isinstance(value, sympy.Basic):
@@ -222,13 +230,6 @@ class SymPyExpression(Expression, ABC):
                                  f"unable to turn into a sympy representation internally") from exc
         return SymPyConstant(sympy_object, type_)
 
-    @classmethod
-    def new_variable(cls, name: str, type_: ExpressionType) -> SymPyVariable:
-        # if a string contains a whitespace it'll be treated as multiple variables in sympy.symbols
-        if ' ' in name:
-            raise ValueError(f"`{name}` should not contain a whitespace!")
-        sympy_var = sympy.symbols(name)
-        return SymPyVariable(sympy_var, type_)
 
     @classmethod
     def new_function_application(cls, function: Expression, arguments: List[Expression]) -> SymPyExpression:
@@ -543,14 +544,14 @@ class SymPyContext(SymPyFunctionApplication, Context):
             return self._unsatisfiable
 
     @property
-    def dict(self) -> Dict[str, Any]:
-        """ User should not write to the return value. """
-        return self._dict
-
-    @property
     def satisfiability_is_known(self) -> bool:
         return not self._unknown
 
+
+    @property
+    def dict(self) -> Dict[str, Any]:
+        """ User should not write to the return value. """
+        return self._dict
 
 class SymPySummation(SymPyExpression, QuantifierExpression):
     def __init__(self, sympy_object: sympy.Basic, type_dict: Dict[sympy.Basic, ExpressionType]):

--- a/neuralpp/symbolic/sympy_interpreter.py
+++ b/neuralpp/symbolic/sympy_interpreter.py
@@ -24,13 +24,6 @@ class SymPyInterpreter(Interpreter, Simplifier):
                 result = result.replace(sympy.symbols(variable), sympy.sympify(value))
         return result
 
-    def eval(self, expression: SymPyExpression, context: Context = TrueContext()):
-        result = SymPyInterpreter._simplify_expression(expression.sympy_object, context)
-        if _is_sympy_value(result):
-            return result
-        else:
-            raise RuntimeError(f"cannot evaluate to a value. The best effort result is {result}.")
-
     @staticmethod
     def purge_type_dict(type_dict: Dict[sympy.Basic, ExpressionType], sympy_object: sympy.Basic) -> \
             Dict[sympy.Basic, ExpressionType]:
@@ -62,3 +55,10 @@ class SymPyInterpreter(Interpreter, Simplifier):
             result_expression = SymPyExpression.from_sympy_object(simplified_sympy_expression, type_dict)
             assert result_expression is not None
             return result_expression
+
+    def eval(self, expression: SymPyExpression, context: Context = TrueContext()):
+        result = SymPyInterpreter._simplify_expression(expression.sympy_object, context)
+        if _is_sympy_value(result):
+            return result
+        else:
+            raise RuntimeError(f"cannot evaluate to a value. The best effort result is {result}.")


### PR DESCRIPTION
I realized that I didn't have an overall understanding of all the components of what was happening in Symbolic. So, I took some time to go through all the files to have a better understanding of how everything is connected (especially when Xiang's internship is ending soon). As I did that, I re-ordered some of the functions to make the files a little bit more readable. 

Reordering:
- __init__ is always the first function in a class
- I tried to keep the function ordering the same through the classes 
- I put the helper functions above the main function (I did this because that was already Xiang's convention of ordering most of the functions

Testing:
- `pytest` in the symbolic test folder
- All already passing tests pass (`normalizer_test.py::test_codegen`is currently failing in main)

Notes:
- https://share.goodnotes.com/s/vC715gvNUscDm3nj06piQR#page-40

TODO:
- Since I have a better overall view of the project, I'm going to try to refine intervals (I wanted to go through all the files so I know what functions I have to my disposal and how interval is being used)