### PR TITLE
Poly implementation cleanup

### DIFF
--- a/neuralpp/symbolic/basic_expression.py
+++ b/neuralpp/symbolic/basic_expression.py
@@ -55,7 +55,7 @@ class BasicAtomicExpression(BasicExpression, AtomicExpression, ABC):
     def __init__(self, atom: Any, expression_type: Optional[ExpressionType] = None):
         if expression_type is None and not isinstance(atom, ExpressionType):
             # try to infer type for atom
-            if isinstance(atom, Callable):
+            if callable(atom):
                 expression_type = infer_python_callable_type(atom)
             else:
                 expression_type = type(atom)

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -203,9 +203,8 @@ class Expression(ABC):
                     f"invalid from_expression {from_expression}: {type(from_expression)}"
                 )
 
-
     def get_return_type(self, number_of_arguments: int) -> ExpressionType:
-        if not isinstance(self.type, Callable):
+        if not isinstance(self.type, type(Callable[..., Any])):
             raise TypeError(f"{self}'s function is not of function type.")
         return return_type_after_application(self.type, number_of_arguments)
 

--- a/neuralpp/symbolic/z3_expression.py
+++ b/neuralpp/symbolic/z3_expression.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 import fractions
 from functools import cached_property, total_ordering
 import typing
-from typing import Any, Dict, Optional, Tuple, List, FrozenSet
+from typing import Any, Dict, Optional, Tuple, List, FrozenSet, Callable
 
 
 import sympy
@@ -104,7 +104,12 @@ class Z3Expression(Expression, ABC):
 
     @classmethod
     def new_variable(cls, name: str, type_: ExpressionType) -> Z3Variable:
-        z3_var = z3.Const(name, type_to_z3_sort(type_))
+        if isinstance(type_, type(Callable[..., Any])):
+            # isinstance(type_, Callable) is wrong: e.g., isinstance(int, Callable)==True
+            argument_types, return_type = typing.get_args(type_)
+            z3_var = z3.Function(name, *map(type_to_z3_sort, argument_types), type_to_z3_sort(return_type))
+        else:
+            z3_var = z3.Const(name, type_to_z3_sort(type_))
         return Z3Variable(z3_var)
 
     @classmethod

--- a/neuralpp/test/quick_tests/symbolic/expression_test.py
+++ b/neuralpp/test/quick_tests/symbolic/expression_test.py
@@ -49,7 +49,7 @@ int_to_int_to_int = Callable[[int, int], int]  # int -> int -> int
 def test_constant(expression_factory):
     # Constant can be anything
     constant_one = expression_factory.new_constant(1)
-    constant_abc = expression_factory.new_constant("abc", Callable[[int], int])
+    constant_abc = expression_factory.new_variable("abc", Callable[[int], int])
     assert not constant_one.internal_object_eq(constant_abc)
     assert constant_one.internal_object_eq(expression_factory.new_constant(2 - 1))
     assert constant_one.subexpressions == []


### PR DESCRIPTION
Created a new class `SymPyPoly` to wrap `sympy.Poly`. It is not a subclass of `FunctionApplication`, because the polynomial can also be a `Constant` (e.g., `1`), or a `Variable` (e.g., `x`).