### PR TITLE
Refactor Interpreter

### DIFF
--- a/neuralpp/symbolic/basic_interpreter.py
+++ b/neuralpp/symbolic/basic_interpreter.py
@@ -3,7 +3,12 @@ import math
 import sympy
 
 from neuralpp.symbolic.interpreter import Interpreter
-from neuralpp.symbolic.expression import Expression, FunctionApplication, Constant, Variable
+from neuralpp.symbolic.expression import (
+    Constant,
+    Expression,
+    FunctionApplication,
+    Variable,
+)
 from neuralpp.symbolic.basic_expression import BasicConstant
 from neuralpp.symbolic.sympy_expression import SymPyExpression
 
@@ -11,21 +16,23 @@ from neuralpp.symbolic.sympy_expression import SymPyExpression
 class BasicInterpreter(Interpreter):
     def eval(self, expression: Expression, context: Expression = BasicConstant(True)):
         """
-        In this BasicInterpreter, `context` is ignored and assumed to be True.
+        In BasicInterpreter, `context` is ignored and assumed to be True.
         `expression` is assumed to only (recursively) contain FunctionApplication and Constant.
         The function raises Error if it
         - encounters a Variable, standalone or in arguments;
         - encounters a Variable as the function (it's an "uninterpreted function")
-        - the function raises Error when called on the arguments. (this is implicitly raised)
+        - is called on the arguments (this is implicitly raised)
         Note the function does not check `context`, since if the result can be evaluated under True context,
         it must also can be evaluated under a weaker one.
         """
         # pattern matching in Python: https://peps.python.org/pep-0636/
         match expression:
-            # there's three cases of `function` that BasicInterpreter can eval():
+            # there's two cases of `function` that BasicInterpreter can eval():
             # 1. a Python callable, which we'll directly call
             # 2. an uninterpreted function, which is not callable. We raise Error when encounter it.
-            case FunctionApplication(function=Constant(value=python_callable), arguments=args):
+            case FunctionApplication(
+                function=Constant(value=python_callable), arguments=args
+            ):
                 # we use piecewise and conditional the same time, piecewise is not a Python callable (sorta hack, maybe we should have a piecewise() in symbolic/functions.py?)
                 if python_callable == sympy.Piecewise:
                     result = float(SymPyExpression.convert(expression).sympy_object)
@@ -36,8 +43,12 @@ class BasicInterpreter(Interpreter):
                     # * is used to turn a list into "args": https://docs.python.org/2/reference/expressions.html#calls
                     return python_callable(*map(self.eval, args))
             case FunctionApplication(function=Variable(name=f), arguments=_):
-                raise AttributeError(f"Function {f} is uninterpreted. It cannot be evaluated by BasicInterpreter.")
+                raise AttributeError(
+                    f"Function {f} is uninterpreted. It cannot be evaluated by BasicInterpreter."
+                )
             case Constant(value=value):
                 return value
             case Variable(name=_):
-                raise AttributeError("BasicInterpreter expects no variables when it eval()")
+                raise AttributeError(
+                    "BasicInterpreter expects no variables when it eval()"
+                )

--- a/neuralpp/symbolic/expression.py
+++ b/neuralpp/symbolic/expression.py
@@ -10,7 +10,8 @@ import neuralpp.symbolic.functions as functions
 from neuralpp.util.callable_util import (
     ExpressionType,
     get_arithmetic_function_type_from_argument_types,
-    return_type_after_application, get_comparison_function_type_from_argument_types,
+    return_type_after_application,
+    get_comparison_function_type_from_argument_types,
 )
 
 
@@ -69,7 +70,7 @@ class Expression(ABC):
 
     @abstractmethod
     def replace(
-            self, from_expression: Expression, to_expression: Expression
+        self, from_expression: Expression, to_expression: Expression
     ) -> Expression:
         """
         Every expression is immutable so replace() returns either self or a new Expression.
@@ -114,32 +115,35 @@ class Expression(ABC):
         match self, other:
             case AtomicExpression(
                 base_type=self_base_type, atom=self_atom, type=_
-            ), AtomicExpression(
-                base_type=other_base_type, atom=other_atom, type=_
-            ):
+            ), AtomicExpression(base_type=other_base_type, atom=other_atom, type=_):
                 # TODO: fix this
                 # return self_base_type == other_base_type and self_type == other_type and self_atom == other_atom
                 return self_base_type == other_base_type and self_atom == other_atom
             case (  # TODO: remove this case, which is taking care of semantic rather than syntactic equality
-                    # At the moment the treatment of Polynomials depends on this because they are represented
-                    # as applications of the identity function. Once we represent them in their own class,
-                    # we can remove this case.
-                     FunctionApplication(function=Constant(value=functions.identity), arguments=identity_arguments),
-                     the_other
-                 ) | \
-                 (
-                     the_other,
-                     FunctionApplication(function=Constant(value=functions.identity), arguments=identity_arguments)
-                 ):
+                # At the moment the treatment of Polynomials depends on this because they are represented
+                # as applications of the identity function. Once we represent them in their own class,
+                # we can remove this case.
+                FunctionApplication(
+                    function=Constant(value=functions.identity),
+                    arguments=identity_arguments,
+                ),
+                the_other,
+            ) | (
+                the_other,
+                FunctionApplication(
+                    function=Constant(value=functions.identity),
+                    arguments=identity_arguments,
+                ),
+            ):
                 assert len(identity_arguments) == 1
                 return identity_arguments[0].syntactic_eq(the_other)
             case (
-                     FunctionApplication(subexpressions=self_subexpressions),
-                     FunctionApplication(subexpressions=other_subexpressions),
-                 ) | (
-                     QuantifierExpression(subexpressions=self_subexpressions),
-                     QuantifierExpression(subexpressions=other_subexpressions),
-                 ):
+                FunctionApplication(subexpressions=self_subexpressions),
+                FunctionApplication(subexpressions=other_subexpressions),
+            ) | (
+                QuantifierExpression(subexpressions=self_subexpressions),
+                QuantifierExpression(subexpressions=other_subexpressions),
+            ):
                 return len(self_subexpressions) == len(other_subexpressions) and all(
                     lhs.syntactic_eq(rhs)
                     for lhs, rhs in zip(self_subexpressions, other_subexpressions)
@@ -166,19 +170,19 @@ class Expression(ABC):
     @classmethod
     @abstractmethod
     def new_function_application(
-            cls, function: Expression, arguments: List[Expression]
+        cls, function: Expression, arguments: List[Expression]
     ) -> Expression:
         pass
 
     @classmethod
     @abstractmethod
     def new_quantifier_expression(
-            cls,
-            operation: Constant,
-            index: Variable,
-            constraint: Expression,
-            body: Expression,
-            is_integral: bool,
+        cls,
+        operation: Constant,
+        index: Variable,
+        constraint: Expression,
+        body: Expression,
+        is_integral: bool,
     ) -> Expression:
         pass
 
@@ -197,12 +201,13 @@ class Expression(ABC):
             case QuantifierExpression(
                 subexpressions=subexpressions, is_integral=is_integral
             ):
-                return cls.new_quantifier_expression(*subexpressions, is_integral=is_integral)
+                return cls.new_quantifier_expression(
+                    *subexpressions, is_integral=is_integral
+                )
             case _:
                 raise ValueError(
                     f"invalid from_expression {from_expression}: {type(from_expression)}"
                 )
-
 
     def get_return_type(self, number_of_arguments: int) -> ExpressionType:
         if not isinstance(self.type, Callable):
@@ -210,7 +215,7 @@ class Expression(ABC):
         return return_type_after_application(self.type, number_of_arguments)
 
     def _new_binary_arithmetic(
-            self, other, operator_, function_type=None, reverse=False
+        self, other, operator_, function_type=None, reverse=False
     ) -> Expression:
         return self._new_binary_operation(
             other, operator_, function_type, reverse, arithmetic=True
@@ -222,7 +227,7 @@ class Expression(ABC):
         )
 
     def _new_binary_comparison(
-            self, other, operator_, function_type=None, reverse=False
+        self, other, operator_, function_type=None, reverse=False
     ) -> Expression:
         return self._new_binary_operation(
             other,
@@ -234,13 +239,13 @@ class Expression(ABC):
         )
 
     def _new_binary_operation(
-            self,
-            other,
-            operator_,
-            function_type=None,
-            reverse=False,
-            arithmetic=True,
-            arithmetic_arguments=False,
+        self,
+        other,
+        operator_,
+        function_type=None,
+        reverse=False,
+        arithmetic=True,
+        arithmetic_arguments=False,
     ) -> Expression:
         """
         Wrapper to make a binary operation in self's class. Tries to convert other to a Constant if it is not
@@ -399,7 +404,7 @@ class AtomicExpression(Expression, ABC):
         return []
 
     def replace(
-            self, from_expression: Expression, to_expression: Expression
+        self, from_expression: Expression, to_expression: Expression
     ) -> Expression:
         if from_expression.syntactic_eq(self):
             return to_expression
@@ -482,7 +487,7 @@ class FunctionApplication(Expression, ABC):
             )
 
     def replace(
-            self, from_expression: Expression, to_expression: Expression
+        self, from_expression: Expression, to_expression: Expression
     ) -> Expression:
         if from_expression.syntactic_eq(self):
             return to_expression
@@ -632,7 +637,7 @@ class QuantifierExpression(Expression, ABC):
         )
 
     def replace(
-            self, from_expression: Expression, to_expression: Expression
+        self, from_expression: Expression, to_expression: Expression
     ) -> Expression:
         if from_expression.syntactic_eq(self):
             return to_expression

--- a/neuralpp/symbolic/interpreter.py
+++ b/neuralpp/symbolic/interpreter.py
@@ -6,7 +6,7 @@ class Interpreter(ABC):
     @abstractmethod
     def eval(self, expression: Expression, context: Context):
         """
-        Evaluations the `expression` under the constraint of `context` being true.
+        Evaluates the `expression` under the constraint of `context` being true.
         Either returns a value s.t., context -> expression == value
         or raise AttributeError when it's too difficult for the Interpreter; or
         raise Error encountered when applying function.

--- a/neuralpp/symbolic/parameters.py
+++ b/neuralpp/symbolic/parameters.py
@@ -23,6 +23,7 @@ class _GlobalParameters(local):
     .. [2] sympy.core.parameters._global_parameters
 
     """
+
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 

--- a/neuralpp/symbolic/sympy_interpreter.py
+++ b/neuralpp/symbolic/sympy_interpreter.py
@@ -27,15 +27,23 @@ class SymPyInterpreter(Interpreter, Simplifier):
         return result
 
     def eval(self, expression: SymPyExpression, context: Context = TrueContext()):
+        """
+        Tries to evaluate the  `expression` using SymPy's simplify.
+        If the `context` is not empty, `eval()` will replace all the variables within the context with
+        its corresponding value. `eval()` will also simplify the corresponding value for the variable.
+        """
         result = SymPyInterpreter._simplify_expression(expression.sympy_object, context)
         if is_sympy_value(result):
             return result
         else:
-            raise RuntimeError(f"cannot evaluate to a value. The best effort result is {result}.")
+            raise RuntimeError(
+                f"cannot evaluate to a value. The best effort result is {result}."
+            )
 
     @staticmethod
-    def purge_type_dict(type_dict: Dict[sympy.Basic, ExpressionType], sympy_object: sympy.Basic) -> \
-            Dict[sympy.Basic, ExpressionType]:
+    def purge_type_dict(
+        type_dict: Dict[sympy.Basic, ExpressionType], sympy_object: sympy.Basic
+    ) -> Dict[sympy.Basic, ExpressionType]:
         """
         Assumes all variables (including uninterpreted functions) used in sympy_object is in type_dict.
         Returns a new type dict that only contains the keys that's used in sympy_object.
@@ -46,23 +54,33 @@ class SymPyInterpreter(Interpreter, Simplifier):
                 result[key] = value
         return result
 
-    def simplify(self, expression: Expression, context: Context = TrueContext()) -> SymPyExpression:
+    def simplify(
+        self, expression: Expression, context: Context = TrueContext()
+    ) -> SymPyExpression:
         """
         The function calls simplify() from sympy library and wrap the result in SymPyExpression.
         """
-        with sympy_evaluate(True):  # To work around a bug in SymPy (see context_simplifier_test.py/test_sympy_bug).
+        with sympy_evaluate(
+            True
+        ):  # To work around a bug in SymPy (see context_simplifier_test.py/test_sympy_bug).
             if not isinstance(expression, SymPyExpression):
                 try:
                     expression = SymPyExpression.convert(expression)
                 except Exception as exc:
                     raise ConversionError() from exc
 
-            simplified_sympy_expression = SymPyInterpreter._simplify_expression(expression.sympy_object, context)
+            simplified_sympy_expression = SymPyInterpreter._simplify_expression(
+                expression.sympy_object, context
+            )
             if expression.type == bool:
                 simplified_sympy_expression = sympy.to_dnf(simplified_sympy_expression)
             # The result keeps the known type information from `expression`. E.g., though (y-y).simplify() = 0, it still
             # keeps the type of `y`. Delete these redundant types.
-            type_dict = SymPyInterpreter.purge_type_dict(expression.type_dict, simplified_sympy_expression)
-            result_expression = SymPyExpression.from_sympy_object(simplified_sympy_expression, type_dict)
+            type_dict = SymPyInterpreter.purge_type_dict(
+                expression.type_dict, simplified_sympy_expression
+            )
+            result_expression = SymPyExpression.from_sympy_object(
+                simplified_sympy_expression, type_dict
+            )
             assert result_expression is not None
             return result_expression


### PR DESCRIPTION
- Ran `black file_name.py -- fast` to help reformat the files
- Changed any relative imports to absolute (I think most people liked absolute imports more in the design meeting we had for relative imports vs. absolute imports)
- Added some docstrings to the interpreter and simplify files