### PR TITLE
branch pruning examples

### DIFF
--- a/neuralpp/symbolic/eliminator.py
+++ b/neuralpp/symbolic/eliminator.py
@@ -111,8 +111,6 @@ class Eliminator:
             else:
                 result = SymPyExpression.symbolic_integral(body, index, interval.lower_bound, interval.upper_bound,
                                                            self.profiler)
-                # result = SymPyExpression.symbolic_integral_cached(body, index, interval.lower_bound,
-                #                                                   interval.upper_bound, self.profiler)
                 return result
 
 

--- a/neuralpp/symbolic/general_normalizer.py
+++ b/neuralpp/symbolic/general_normalizer.py
@@ -126,6 +126,7 @@ class GeneralNormalizer(Normalizer):
                 if context.contains(index):
                     raise ValueError(f"context {context} should not contain index {index}")
                 if context.is_known_to_imply(~constraint):
+                    # simple unsatisfiable interval is eliminated here, e.g., [-4,0] & [1,2]
                     return operation.identity
 
                 if body_is_normalized:

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -530,15 +530,11 @@ class SymPyFunctionApplication(SymPyFunctionApplicationInterface):
                             for i in range(1, len(native_arguments)):
                                 if native_arguments[i] == 0:
                                     continue
-                                print("not 0:", native_arguments[i])
                                 if sympy_object.is_Poly:
-                                    print("1", sympy_object)
                                     sympy_object = sympy_object.add(native_arguments[i])
                                 elif native_arguments[i].is_Poly:
-                                    print("2")
                                     sympy_object = native_arguments[i].add(sympy_object)
                                 else:
-                                    print("3")
                                     sympy_object += native_arguments[i]
                         else:
                             raise RuntimeError(f"Unknown function {sympy_function}")

--- a/neuralpp/symbolic/sympy_expression.py
+++ b/neuralpp/symbolic/sympy_expression.py
@@ -196,6 +196,8 @@ class SymPyExpression(Expression, ABC):
                 a = big_f.replace(index.sympy_object, lower_bound.sympy_object)
             with profiler.profile_section("compute diff"):
                 diff = b - a
+                if all([gen.is_number for gen in diff.gens]):
+                    diff = diff.expr
             with profiler.profile_section("wrap"):
                 result = SymPyExpression.from_sympy_object(diff, type_dict)
             return result
@@ -524,7 +526,20 @@ class SymPyFunctionApplication(SymPyFunctionApplicationInterface):
                             sympy_object = native_arguments[0].mul(native_arguments[1])
                         elif sympy_function == sympy.Add:
                             # we should do something similar to the case above
-                            raise NotImplementedError("This path is not current used")
+                            sympy_object = native_arguments[0]
+                            for i in range(1, len(native_arguments)):
+                                if native_arguments[i] == 0:
+                                    continue
+                                print("not 0:", native_arguments[i])
+                                if sympy_object.is_Poly:
+                                    print("1", sympy_object)
+                                    sympy_object = sympy_object.add(native_arguments[i])
+                                elif native_arguments[i].is_Poly:
+                                    print("2")
+                                    sympy_object = native_arguments[i].add(sympy_object)
+                                else:
+                                    print("3")
+                                    sympy_object += native_arguments[i]
                         else:
                             raise RuntimeError(f"Unknown function {sympy_function}")
                     else:


### PR DESCRIPTION
@rodrigodesalvobraz and I discussed a bit an example where z3 is helpful to prune branches. We decided to go with an example of (the integration of) the square of normal.

Here's a commit implementing this, with `evaluation_general_with_result` we can see the function prints the correct results for both [-20,20] (≈[-oo,oo]) and [-20,1] (≈[-oo,1]).

However, in this example, we don't even need z3: for simple pruning like `[-4,-13/4] & [13/4,4]`, sympy will automatically reduce this to `False`, so even with `Z3SolverExpressionDummy` as context, we can see the pruning of branch.